### PR TITLE
Centralize resource authorization decisions

### DIFF
--- a/client/src/api/quadcoachApi/domain/ResourceAuthorization.ts
+++ b/client/src/api/quadcoachApi/domain/ResourceAuthorization.ts
@@ -1,0 +1,22 @@
+export type ResourceAccessLevel = "view" | "edit";
+
+export type ResourceAuthorizationBasis =
+  | "owner"
+  | "admin"
+  | "granted"
+  | "public";
+
+export type ResourceAuthorizationResponse = {
+  hasAccess: boolean;
+  type: ResourceAuthorizationBasis | null;
+  level: ResourceAccessLevel | null;
+};
+
+export const canEditResource = (
+  authorization: ResourceAuthorizationResponse | undefined,
+): boolean => authorization?.level === "edit";
+
+export const canManageResource = (
+  authorization: ResourceAuthorizationResponse | undefined,
+): boolean =>
+  authorization?.type === "owner" || authorization?.type === "admin";

--- a/client/src/api/quadcoachApi/domain/index.ts
+++ b/client/src/api/quadcoachApi/domain/index.ts
@@ -11,3 +11,9 @@ export type {
   TacticBoardPartialId,
 } from "./TacticBoard";
 export type { default as User, UserWithOutId, UserPartialId } from "./User";
+export type {
+  ResourceAccessLevel,
+  ResourceAuthorizationBasis,
+  ResourceAuthorizationResponse,
+} from "./ResourceAuthorization";
+export { canEditResource, canManageResource } from "./ResourceAuthorization";

--- a/client/src/api/quadcoachApi/practicePlansApi.ts
+++ b/client/src/api/quadcoachApi/practicePlansApi.ts
@@ -6,7 +6,12 @@ import type {
   PracticePlanSection,
   PracticePlanHeader,
 } from "./domain/PracticePlan";
-import { AccessLevel } from "./tacticboardApi";
+import type {
+  ResourceAccessLevel,
+  ResourceAuthorizationResponse,
+} from "./domain";
+
+export type AccessLevel = ResourceAccessLevel;
 
 export interface CreatePracticePlanRequest {
   name: string;
@@ -30,12 +35,6 @@ export type PracticePlanAccessEntry = {
   practicePlan: string;
   access: AccessLevel;
   createdAt: string;
-};
-
-export type AccessResponse = {
-  hasAccess: boolean;
-  type: "owner" | "admin" | "granted" | "public" | null;
-  level: AccessLevel | null;
 };
 
 export type ShareLinkResponse = {
@@ -184,6 +183,18 @@ export const practicePlansApiSlice = quadcoachApi.injectEndpoints({
       }),
       invalidatesTags: [TagType.practiceplan],
     }),
+    checkPracticePlanAccess: builder.query<
+      ResourceAuthorizationResponse,
+      string
+    >({
+      query: (practicePlanId) => ({
+        url: `/api/practice-plans/${practicePlanId}/checkAccess`,
+        method: "get",
+      }),
+      providesTags: (_result, _error, practicePlanId) => [
+        { type: TagType.practiceplan, id: `${practicePlanId}-access` },
+      ],
+    }),
     getAllPracticePlanAccessUsers: builder.query<
       PracticePlanAccessEntry[],
       string
@@ -264,6 +275,7 @@ export const {
   useGetSharedPracticePlanQuery,
   usePatchPracticePlanMutation,
   useDeletePracticePlanMutation,
+  useCheckPracticePlanAccessQuery,
   useGetAllPracticePlanAccessUsersQuery,
   useAddPracticePlanAccessMutation,
   useRemovePracticePlanAccessMutation,

--- a/client/src/api/quadcoachApi/practicePlansApi.ts
+++ b/client/src/api/quadcoachApi/practicePlansApi.ts
@@ -34,7 +34,7 @@ export type PracticePlanAccessEntry = {
 
 export type AccessResponse = {
   hasAccess: boolean;
-  type: "owner" | "admin" | "granted" | null;
+  type: "owner" | "admin" | "granted" | "public" | null;
   level: AccessLevel | null;
 };
 

--- a/client/src/api/quadcoachApi/tacticboardApi.ts
+++ b/client/src/api/quadcoachApi/tacticboardApi.ts
@@ -1,6 +1,11 @@
 import { quadcoachApi } from "..";
 import { TagType } from "../enum";
-import { TacticBoard, TacticPage } from "./domain";
+import {
+  ResourceAccessLevel,
+  ResourceAuthorizationResponse,
+  TacticBoard,
+  TacticPage,
+} from "./domain";
 import { TacticBoardWithOutIds } from "./domain/TacticBoard";
 import { TacticBoardHeader } from "./domain/TacticBoard";
 
@@ -35,7 +40,7 @@ export type GetTacticBoardResponse = {
   };
 };
 
-export type AccessLevel = "view" | "edit";
+export type AccessLevel = ResourceAccessLevel;
 
 export type AccessEntry = {
   user: {
@@ -45,12 +50,6 @@ export type AccessEntry = {
   tacticboard: string;
   access: AccessLevel;
   createdAt: string;
-};
-
-export type AccessResponse = {
-  hasAccess: boolean;
-  type: "owner" | "admin" | "granted" | "public" | null;
-  level: AccessLevel | null;
 };
 
 export type ShareLinkResponse = {
@@ -364,7 +363,10 @@ export const tacticBoardApiSlice = quadcoachApi.injectEndpoints({
             ]
           : [TagType.tacticboard],
     }),
-    checkTacticboardAccess: builder.query<AccessResponse, string>({
+    checkTacticboardAccess: builder.query<
+      ResourceAuthorizationResponse,
+      string
+    >({
       query: (tacticboardId) => ({
         url: `/api/tacticboards/${tacticboardId}/checkAccess`,
         method: "get",

--- a/client/src/api/quadcoachApi/tacticboardApi.ts
+++ b/client/src/api/quadcoachApi/tacticboardApi.ts
@@ -49,7 +49,7 @@ export type AccessEntry = {
 
 export type AccessResponse = {
   hasAccess: boolean;
-  type: "owner" | "admin" | "granted" | null;
+  type: "owner" | "admin" | "granted" | "public" | null;
   level: AccessLevel | null;
 };
 

--- a/client/src/pages/Exercises/Exercise/ViewExercise/Exercise.tsx
+++ b/client/src/pages/Exercises/Exercise/ViewExercise/Exercise.tsx
@@ -28,6 +28,7 @@ import {
   useGetAllExerciseAccessUsersQuery,
   useShareExerciseMutation,
   useDeleteExerciseAccessMutation,
+  useCheckExerciseAccessQuery,
 } from "../../../exerciseApi";
 import { useTranslation } from "react-i18next";
 import {
@@ -50,7 +51,12 @@ import {
   useRemoveFavoriteExerciseMutation,
 } from "../../../../api/quadcoachApi/favoriteApi";
 
-import { ExercisePartialId, Block } from "../../../../api/quadcoachApi/domain";
+import {
+  Block,
+  canEditResource,
+  canManageResource,
+  ExercisePartialId,
+} from "../../../../api/quadcoachApi/domain";
 import {
   FormikProvider,
   useFormik,
@@ -71,8 +77,7 @@ const Exercise = () => {
   const { t } = useTranslation("Exercise");
   const { id: exerciseId } = useParams();
   const navigate = useNavigate();
-  const [isPrivileged, setIsPrivileged] = useState<boolean>(false);
-  const { id: userId, roles: userRoles } = useAuth();
+  const { id: userId } = useAuth();
   const [isFavorite, setIsFavorite] = useState<boolean>(false);
   const [userEmail, setUserEmail] = useState<string>("");
   const [emailError, setEmailError] = useState<string>("");
@@ -114,15 +119,16 @@ const Exercise = () => {
   const [getFavoriteExercises, { data: favoriteExercises }] =
     useLazyGetFavoriteExercisesQuery();
 
+  const { data: authorization } = useCheckExerciseAccessQuery(
+    exerciseId || "",
+    { skip: !exerciseId || !userId },
+  );
+  const canEdit = canEditResource(authorization);
+  const canManageResourceActions = canManageResource(authorization);
   const { data: accessUsers } = useGetAllExerciseAccessUsersQuery(
     exerciseId || "",
-    { skip: !exerciseId },
+    { skip: !exerciseId || !canManageResourceActions },
   );
-
-  const isCreator =
-    exercise?.user?.toString() === userId ||
-    userRoles.includes("Admin") ||
-    userRoles.includes("admin");
 
   const [shareExercise, { isLoading: isShareExerciseLoading }] =
     useShareExerciseMutation();
@@ -152,27 +158,6 @@ const Exercise = () => {
       );
     }
   }, [favoriteExercises, setIsFavorite, exerciseId]);
-
-  useEffect(() => {
-    if (!userId) {
-      setIsPrivileged(false);
-      return;
-    }
-    if (isCreator) {
-      setIsPrivileged(true);
-      return;
-    }
-    if (
-      accessUsers &&
-      accessUsers.some(
-        (entry) => entry.user._id === userId && entry.access === "edit",
-      )
-    ) {
-      setIsPrivileged(true);
-    } else {
-      setIsPrivileged(false);
-    }
-  }, [userId, isCreator, accessUsers]);
 
   // Add update exercise mutation
   const [
@@ -289,7 +274,7 @@ const Exercise = () => {
   // Auto-enter edit mode if URL has ?edit=1 and user is privileged (runs after formik init)
   useEffect(() => {
     if (autoEditAppliedRef.current) return;
-    if (!isEditMode && isPrivileged) {
+    if (!isEditMode && canEdit) {
       const params = new URLSearchParams(location.search);
       if (params.get("edit") === "1") {
         autoEditAppliedRef.current = true;
@@ -305,11 +290,11 @@ const Exercise = () => {
         autoEditAppliedRef.current = true; // no edit flag; avoid re-checking
       }
     }
-  }, [location.search, isPrivileged, isEditMode, formik, location.pathname]);
+  }, [location.search, canEdit, isEditMode, formik, location.pathname]);
 
   // Edit mode toggle functionality
   const onToggleEditMode = async () => {
-    if (!isPrivileged) return;
+    if (!canEdit) return;
     if (isEditMode) {
       const errors = await formik.validateForm();
       if (Object.keys(errors).length === 0) {
@@ -454,7 +439,7 @@ const Exercise = () => {
 
   const exerciseMenuActions: HeaderOverflowAction[] = [];
 
-  if (isPrivileged) {
+  if (canManageResourceActions) {
     exerciseMenuActions.push({
       key: "delete",
       label: t("Exercise:menu.delete"),
@@ -511,7 +496,7 @@ const Exercise = () => {
               </IconButton>
             </Tooltip>
           )}
-          {isPrivileged && (
+          {canEdit && (
             <Tooltip
               title={t("Exercise:updateExercise", {
                 context: isEditMode ? "editMode" : "viewMode",
@@ -565,7 +550,7 @@ const Exercise = () => {
               />
             </Tooltip>
           ),
-          isPrivileged && (
+          canEdit && (
             <Tooltip
               key="edit"
               title={t("Exercise:updateExercise", {
@@ -727,7 +712,7 @@ const Exercise = () => {
             />
           )}
 
-          {isEditMode && isCreator && (
+          {isEditMode && canManageResourceActions && (
             <Accordion defaultExpanded>
               <AccordionSummary expandIcon={<ExpandMoreIcon />}>
                 {t("Exercise:access.title")}

--- a/client/src/pages/PracticePlanner/PracticePlanner.tsx
+++ b/client/src/pages/PracticePlanner/PracticePlanner.tsx
@@ -41,8 +41,9 @@ import {
   useCreatePracticePlanShareLinkMutation,
   useDeletePracticePlanShareLinkMutation,
   useRemovePracticePlanAccessMutation,
+  useCheckPracticePlanAccessQuery,
+  AccessLevel,
 } from "../../api/quadcoachApi/practicePlansApi";
-import { AccessLevel } from "../../api/quadcoachApi/tacticboardApi";
 import {
   useAddFavoritePracticePlanMutation,
   useRemoveFavoritePracticePlanMutation,
@@ -71,6 +72,10 @@ import { useFormik } from "formik";
 
 import { FieldArray, FieldArrayRenderProps, FormikProvider } from "formik";
 import { PracticePlanEntityPartialId } from "../../api/quadcoachApi/domain/PracticePlan";
+import {
+  canEditResource,
+  canManageResource,
+} from "../../api/quadcoachApi/domain";
 import PracticeSection from "./PracticeSection";
 import { lazy, Suspense } from "react";
 import MDEditor from "@uiw/react-md-editor";
@@ -91,10 +96,9 @@ const PracticePlanner = ({
   const { t } = useTranslation("PracticePlanner");
   const navigate = useNavigate();
   const location = useLocation();
-  const [isPrivileged, setIsPrivileged] = useState<boolean>(false);
   const [isFavorite, setIsFavorite] = useState<boolean>(false);
   const [isEditMode, setIsEditMode] = useState<boolean>(false);
-  const { id: userId, roles: userRoles } = useAuth();
+  const { id: userId } = useAuth();
   const autoEditAppliedRef = useRef(false);
   // Track whether to show validation summary (only after failed save attempt)
   const [showValidationSummary, setShowValidationSummary] =
@@ -137,6 +141,12 @@ const PracticePlanner = ({
   const isPlanLoading = isSharedMode ? isSharedPlanLoading : isOwnPlanLoading;
   const isPlanError = isSharedMode ? isSharedPlanError : isOwnPlanError;
   const currentPlanId = planId || plan?._id;
+  const { data: authorization } = useCheckPracticePlanAccessQuery(
+    currentPlanId || "",
+    { skip: !currentPlanId || !userId || isSharedMode },
+  );
+  const canEdit = canEditResource(authorization);
+  const canManageResourceActions = canManageResource(authorization);
   const [
     updatePlan,
     { isLoading: isUpdatePlanLoading, isSuccess: isUpdatePlanSuccess },
@@ -158,8 +168,8 @@ const PracticePlanner = ({
     useRemoveFavoritePracticePlanMutation();
 
   const { data: accessUsers } = useGetAllPracticePlanAccessUsersQuery(
-    planId || "",
-    { skip: !planId || !userId || userId === "" || isSharedMode },
+    currentPlanId || "",
+    { skip: !currentPlanId || !canManageResourceActions },
   );
 
   const [sharePracticePlan, { isLoading: isSharePracticePlanLoading }] =
@@ -174,12 +184,6 @@ const PracticePlanner = ({
     removePracticePlanAccess,
     { isLoading: isRemovePracticePlanAccessLoading },
   ] = useRemovePracticePlanAccessMutation();
-
-  const isCreator =
-    !isSharedMode &&
-    (plan?.user?.toString() === userId ||
-      userRoles.includes("Admin") ||
-      userRoles.includes("admin"));
 
   useEffect(() => {
     if (userId) {
@@ -196,31 +200,6 @@ const PracticePlanner = ({
       );
     }
   }, [favoritePlans, setIsFavorite, currentPlanId]);
-  useEffect(() => {
-    if (isSharedMode) {
-      setIsPrivileged(false);
-      return;
-    }
-    if (!userId) {
-      setIsPrivileged(false);
-      return;
-    }
-    if (isCreator) {
-      setIsPrivileged(true);
-      return;
-    }
-    if (
-      accessUsers &&
-      accessUsers.some(
-        (entry) => entry.user._id === userId && entry.access === "edit",
-      )
-    ) {
-      setIsPrivileged(true);
-    } else {
-      setIsPrivileged(false);
-    }
-  }, [userId, isCreator, accessUsers, isSharedMode]);
-
   useEffect(() => {
     if (plan?.shareToken) {
       setShareLink(
@@ -371,7 +350,7 @@ const PracticePlanner = ({
   // Auto-enter edit mode if URL has ?edit=1 and user is privileged (runs after formik init)
   useEffect(() => {
     if (autoEditAppliedRef.current) return;
-    if (!isEditMode && isPrivileged) {
+    if (!isEditMode && canEdit) {
       const params = new URLSearchParams(location.search);
       if (params.get("edit") === "1") {
         autoEditAppliedRef.current = true;
@@ -387,11 +366,11 @@ const PracticePlanner = ({
         autoEditAppliedRef.current = true; // no edit flag; avoid re-checking
       }
     }
-  }, [location.search, isPrivileged, isEditMode, formik, location.pathname]);
+  }, [location.search, canEdit, isEditMode, formik, location.pathname]);
 
   // Edit mode toggle functionality
   const onToggleEditMode = async () => {
-    if (!isPrivileged) return;
+    if (!canEdit) return;
     if (isEditMode) {
       const errors = await formik.validateForm();
       if (Object.keys(errors).length === 0) {
@@ -522,7 +501,7 @@ const PracticePlanner = ({
 
   const practicePlanMenuActions: HeaderOverflowAction[] = [];
 
-  if (isPrivileged && plan.isPrivate) {
+  if (canEdit && plan.isPrivate) {
     practicePlanMenuActions.push({
       key: "share",
       label: t(plan.shareToken ? "menu.unshare" : "menu.share"),
@@ -532,7 +511,7 @@ const PracticePlanner = ({
     });
   }
 
-  if (isPrivileged) {
+  if (canManageResourceActions) {
     practicePlanMenuActions.push({
       key: "delete",
       label: t("menu.delete"),
@@ -588,7 +567,7 @@ const PracticePlanner = ({
               </IconButton>
             </Tooltip>
           )}
-          {isPrivileged && (
+          {canEdit && (
             <Tooltip
               title={t("updatePracticePlan", {
                 context: isEditMode ? "editMode" : "viewMode",
@@ -643,7 +622,7 @@ const PracticePlanner = ({
               />
             </Tooltip>
           ),
-          isPrivileged && (
+          canEdit && (
             <Tooltip
               key="edit"
               title={t("updatePracticePlan", {
@@ -689,8 +668,8 @@ const PracticePlanner = ({
                 </Alert>
               )}
 
-            {/* Access Management Card - only shown in edit mode for creators */}
-            {isEditMode && isCreator && (
+            {/* Visibility and Access management */}
+            {isEditMode && (
               <Card sx={{ mb: 3 }}>
                 <SoftBox p={3}>
                   <SoftTypography variant="h6" fontWeight="medium" mb={2}>
@@ -716,107 +695,113 @@ const PracticePlanner = ({
                   </FormGroup>
 
                   {/* User Access Management */}
-                  <Box sx={{ mt: 3 }}>
-                    <SoftTypography variant="body2" fontWeight="medium" mb={2}>
-                      {t("access.manageUsers")}
-                    </SoftTypography>
+                  {canManageResourceActions && (
+                    <Box sx={{ mt: 3 }}>
+                      <SoftTypography
+                        variant="body2"
+                        fontWeight="medium"
+                        mb={2}
+                      >
+                        {t("access.manageUsers")}
+                      </SoftTypography>
 
-                    <Box
-                      sx={{
-                        display: "flex",
-                        gap: 1,
-                        alignItems: "flex-start",
-                        mb: 2,
-                      }}
-                    >
-                      <TextField
-                        size="small"
-                        label={t("access.add_user")}
-                        placeholder="Enter user email"
-                        value={userEmail}
-                        onChange={(e) => {
-                          setUserEmail(e.target.value);
-                          if (emailError) setEmailError("");
-                        }}
-                        error={!!emailError}
-                        helperText={emailError}
+                      <Box
                         sx={{
-                          flex: 1,
-                          minWidth: 250,
-                          "& .MuiInputBase-root": {
-                            height: "40px",
-                          },
-                          "& .MuiInputBase-input": {
-                            padding: "8.5px 14px",
-                          },
-                        }}
-                      />
-                      <TextField
-                        select
-                        size="small"
-                        label={t("access.mode")}
-                        value={accessMode}
-                        onChange={(event) =>
-                          setAccessMode(event.target.value as AccessLevel)
-                        }
-                        sx={{
-                          minWidth: 120,
-                          width: 120,
-                          "& .MuiInputBase-root": {
-                            height: "40px",
-                          },
-                          "& .MuiInputBase-input": {
-                            padding: "8.5px 14px",
-                          },
+                          display: "flex",
+                          gap: 1,
+                          alignItems: "flex-start",
+                          mb: 2,
                         }}
                       >
-                        <MenuItem value="edit">{t("access.edit")}</MenuItem>
-                        <MenuItem value="view">{t("access.view")}</MenuItem>
-                      </TextField>
-                      <Button
-                        variant="contained"
-                        size="small"
-                        disabled={
-                          isSharePracticePlanLoading || !userEmail.trim()
-                        }
-                        onClick={handleAddAccess}
-                        sx={{ height: "40px", minWidth: "80px" }}
-                      >
-                        {t("access.add")}
-                      </Button>
-                    </Box>
-
-                    <List>
-                      {accessUsers?.map((entry) => (
-                        <ListItem
-                          key={entry.user._id}
-                          secondaryAction={
-                            <Button
-                              size="small"
-                              color="error"
-                              disabled={isRemovePracticePlanAccessLoading}
-                              onClick={() => {
-                                if (planId) {
-                                  removePracticePlanAccess({
-                                    practicePlan: planId,
-                                    userId: entry.user._id,
-                                  });
-                                }
-                              }}
-                            >
-                              {t("access.remove")}
-                            </Button>
+                        <TextField
+                          size="small"
+                          label={t("access.add_user")}
+                          placeholder="Enter user email"
+                          value={userEmail}
+                          onChange={(e) => {
+                            setUserEmail(e.target.value);
+                            if (emailError) setEmailError("");
+                          }}
+                          error={!!emailError}
+                          helperText={emailError}
+                          sx={{
+                            flex: 1,
+                            minWidth: 250,
+                            "& .MuiInputBase-root": {
+                              height: "40px",
+                            },
+                            "& .MuiInputBase-input": {
+                              padding: "8.5px 14px",
+                            },
+                          }}
+                        />
+                        <TextField
+                          select
+                          size="small"
+                          label={t("access.mode")}
+                          value={accessMode}
+                          onChange={(event) =>
+                            setAccessMode(event.target.value as AccessLevel)
                           }
+                          sx={{
+                            minWidth: 120,
+                            width: 120,
+                            "& .MuiInputBase-root": {
+                              height: "40px",
+                            },
+                            "& .MuiInputBase-input": {
+                              padding: "8.5px 14px",
+                            },
+                          }}
                         >
-                          <ListItemText
-                            primary={
-                              entry.user.name + " (" + entry.access + ")"
+                          <MenuItem value="edit">{t("access.edit")}</MenuItem>
+                          <MenuItem value="view">{t("access.view")}</MenuItem>
+                        </TextField>
+                        <Button
+                          variant="contained"
+                          size="small"
+                          disabled={
+                            isSharePracticePlanLoading || !userEmail.trim()
+                          }
+                          onClick={handleAddAccess}
+                          sx={{ height: "40px", minWidth: "80px" }}
+                        >
+                          {t("access.add")}
+                        </Button>
+                      </Box>
+
+                      <List>
+                        {accessUsers?.map((entry) => (
+                          <ListItem
+                            key={entry.user._id}
+                            secondaryAction={
+                              <Button
+                                size="small"
+                                color="error"
+                                disabled={isRemovePracticePlanAccessLoading}
+                                onClick={() => {
+                                  if (planId) {
+                                    removePracticePlanAccess({
+                                      practicePlan: planId,
+                                      userId: entry.user._id,
+                                    });
+                                  }
+                                }}
+                              >
+                                {t("access.remove")}
+                              </Button>
                             }
-                          />
-                        </ListItem>
-                      ))}
-                    </List>
-                  </Box>
+                          >
+                            <ListItemText
+                              primary={
+                                entry.user.name + " (" + entry.access + ")"
+                              }
+                            />
+                          </ListItem>
+                        ))}
+                      </List>
+                    </Box>
+                  )}
                 </SoftBox>
               </Card>
             )}

--- a/client/src/pages/TacticBoard/TacticBoard.tsx
+++ b/client/src/pages/TacticBoard/TacticBoard.tsx
@@ -10,13 +10,18 @@ import {
   useCreateTacticBoardPageMutation,
   useDeleteTacticBoardMutation,
   useDeleteTacticBoardPageMutation,
-  useGetAllTacticboardAccessUsersQuery,
+  useCheckTacticboardAccessQuery,
   useGetTacticBoardQuery,
   useInsertTacticBoardPageMutation,
   useUpdateTacticBoardPageMutation,
 } from "../../api/quadcoachApi/tacticboardApi";
 import "../fullscreen.css";
-import { TacticBoard, TacticPage } from "../../api/quadcoachApi/domain";
+import {
+  canEditResource,
+  canManageResource,
+  TacticBoard,
+  TacticPage,
+} from "../../api/quadcoachApi/domain";
 import {
   useTacticBoardCanvas,
   useTacticBoardData,
@@ -76,20 +81,21 @@ const TacticsBoard = (): JSX.Element => {
     useDeleteTacticBoardPageMutation();
   const [deleteTacticBoard] = useDeleteTacticBoardMutation();
 
-  const { data: accessUsers } = useGetAllTacticboardAccessUsersQuery(
-    tacticBoardId || "",
-  );
-
   const [currentPage, setPage] = useState<number>(1);
   const [maxPages, setMaxPages] = useState<number>(1);
   const [isAnimating, setIsAnimating] = useState<boolean>(false);
   const [isFullScreen, setIsFullScreen] = useState<boolean>(false);
-  const [isPrivileged, setIsPrivileged] = useState<boolean>(false);
   const [firstAPICall, setFirstAPICall] = useState<number>(0);
 
   const isEditMode = useAppSelector((state) => state.tacticBoard.isEditMode);
 
-  const { id: userId, roles: userRoles } = useAuth();
+  const { id: userId } = useAuth();
+  const { data: authorization } = useCheckTacticboardAccessQuery(
+    tacticBoardId || "",
+    { skip: !tacticBoardId || !userId },
+  );
+  const canEdit = canEditResource(authorization);
+  const canDelete = canManageResource(authorization);
 
   const onDeleteActiveObject = () => {
     removeActiveObjects();
@@ -110,7 +116,7 @@ const TacticsBoard = (): JSX.Element => {
         return;
       if (!tacticBoard) return;
       const updatedTacticBoard: TacticBoard = cloneDeep(tacticBoard);
-      if (isPrivileged && isEditMode) {
+      if (canEdit && isEditMode) {
         if (newPage) {
           updatedTacticBoard.pages[page - 1] = {
             ...updatedTacticBoard.pages[page - 1],
@@ -219,7 +225,7 @@ const TacticsBoard = (): JSX.Element => {
       }
       loadFromJson(updatedTacticBoard.pages[page - 1]);
 
-      if (isPrivileged && isEditMode) {
+      if (canEdit && isEditMode) {
         setSelection(true);
       } else {
         setSelection(false);
@@ -228,7 +234,7 @@ const TacticsBoard = (): JSX.Element => {
     },
     [
       tacticBoard,
-      isPrivileged,
+      canEdit,
       isEditMode,
       loadFromJson,
       setControls,
@@ -456,26 +462,6 @@ const TacticsBoard = (): JSX.Element => {
     };
   }, []);
 
-  useEffect(() => {
-    if (
-      userId == tacticBoard?.user ||
-      userRoles.includes("Admin") ||
-      userRoles.includes("admin")
-    ) {
-      setIsPrivileged(true);
-    } else {
-      if (accessUsers) {
-        setIsPrivileged(
-          accessUsers.some((user) => {
-            return (
-              user.user._id.toString() === userId && user.access === "edit"
-            );
-          }),
-        );
-      }
-    }
-  }, [userId, tacticBoard, userRoles, accessUsers]);
-
   return (
     <SoftBox
       sx={{
@@ -532,7 +518,8 @@ const TacticsBoard = (): JSX.Element => {
               isDeletePageLoading
             }
             tacticBoard={tacticBoard}
-            isPrivileged={isPrivileged}
+            canEdit={canEdit}
+            canDelete={canDelete}
             currentPage={currentPage}
             onLoadPage={onLoadPage}
             setPage={setPage}
@@ -565,7 +552,7 @@ const TacticsBoard = (): JSX.Element => {
             >
               {isEditMode && (
                 <TacticBoardTopItemsMenu
-                  isPrivileged={isPrivileged}
+                  canEdit={canEdit}
                   isEditMode={isEditMode}
                   onDelete={onDeleteActiveObject}
                 />

--- a/client/src/pages/TacticBoard/TacticBoardTopItemsMenu/TacticBoardTopItemsMenu.tsx
+++ b/client/src/pages/TacticBoard/TacticBoardTopItemsMenu/TacticBoardTopItemsMenu.tsx
@@ -33,7 +33,7 @@ import { v4 as uuidv4 } from "uuid";
 import { setUuid } from "../../../contexts/tacticBoard/TacticBoardFabricJsContext/fabricTypes";
 
 type TacticBoardTopItemMenuProps = {
-  isPrivileged: boolean;
+  canEdit: boolean;
   isEditMode: boolean;
   onDelete: () => void;
 };
@@ -41,7 +41,7 @@ type TacticBoardTopItemMenuProps = {
 type ToolType = "cursor" | "pencil" | "line" | "text";
 
 const TacticBoardTopItemsMenu = ({
-  isPrivileged,
+  canEdit,
   isEditMode,
   onDelete,
 }: TacticBoardTopItemMenuProps): JSX.Element => {
@@ -81,12 +81,10 @@ const TacticBoardTopItemsMenu = ({
   const [currentFontSize, setCurrentFontSize] = useState<number>(24);
 
   const [currentThickness, setCurrentThickness] = useState(1);
-  const [currentLineStyle, setCurrentLineStyle] = useState<LineStyle>(
-    getLineStyle(),
-  );
-  const [arrowTipEnabled, setArrowTipEnabledState] = useState<boolean>(
-    getArrowTipEnabled(),
-  );
+  const [currentLineStyle, setCurrentLineStyle] =
+    useState<LineStyle>(getLineStyle());
+  const [arrowTipEnabled, setArrowTipEnabledState] =
+    useState<boolean>(getArrowTipEnabled());
 
   const toggleItems = () => {
     dispatch(toggleTacticBoardItemsDrawerOpen());
@@ -101,7 +99,7 @@ const TacticBoardTopItemsMenu = ({
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Delete" && isPrivileged && isEditMode) {
+      if (event.key === "Delete" && canEdit && isEditMode) {
         onDelete();
       }
     };
@@ -110,7 +108,7 @@ const TacticBoardTopItemsMenu = ({
     return () => {
       window.removeEventListener("keydown", handleKeyDown);
     };
-  }, [isPrivileged, isEditMode, onDelete]);
+  }, [canEdit, isEditMode, onDelete]);
 
   const syncSelectedTextbox = useCallback(() => {
     const canvas = canvasFabricRef.current;
@@ -326,7 +324,7 @@ const TacticBoardTopItemsMenu = ({
         }}
       >
         {/* MENU BUTTON START */}
-        {isPrivileged && isEditMode && (
+        {canEdit && isEditMode && (
           <Tooltip
             title={t("TacticBoard:topMenu.itemsMenuButton.tooltip", {
               context: tacticBoardItemsDrawerOpen ? "open" : "closed",
@@ -349,7 +347,7 @@ const TacticBoardTopItemsMenu = ({
         )}
         {/* MENU BUTTON END */}
         {/* DRAW BUTTON START */}
-        {isPrivileged && isEditMode && (
+        {canEdit && isEditMode && (
           <>
             <Select
               id="tool-select"
@@ -481,7 +479,7 @@ const TacticBoardTopItemsMenu = ({
         )}
         {/* DRAW BUTTON END */}
 
-        {isPrivileged && isEditMode && selectedTextbox && (
+        {canEdit && isEditMode && selectedTextbox && (
           <>
             <Tooltip title={t("TacticBoard:topMenu.textColorButton.tooltip")}>
               <span>
@@ -533,7 +531,7 @@ const TacticBoardTopItemsMenu = ({
         {/* TEXT BUTTON END */}
 
         {/* DELETE BUTTON START */}
-        {isPrivileged && isEditMode && (
+        {canEdit && isEditMode && (
           <Tooltip title={t("TacticBoard:topMenu.objectDeleteButton.tooltip")}>
             <span>
               <ToggleButton

--- a/client/src/pages/TacticBoard/TacticBoardTopMenu/TacticBoardTopMenu.tsx
+++ b/client/src/pages/TacticBoard/TacticBoardTopMenu/TacticBoardTopMenu.tsx
@@ -33,7 +33,8 @@ type TacticBoardTopMenuProps = {
   saveTacticBoard: () => void;
   tacticBoard: TacticBoard;
   isTacticBoardLoading: boolean;
-  isPrivileged: boolean;
+  canEdit: boolean;
+  canDelete: boolean;
   currentPage: number;
   onLoadPage: (
     page: number,
@@ -56,7 +57,8 @@ const TacticBoardTopMenu = ({
   saveTacticBoard,
   tacticBoard,
   isTacticBoardLoading,
-  isPrivileged,
+  canEdit,
+  canDelete,
   currentPage,
   onLoadPage,
   setPage,
@@ -77,7 +79,7 @@ const TacticBoardTopMenu = ({
   const [showDeleteConfirmation, setShowDeleteConfirmation] = useState(false);
 
   const onToggleEditMode = () => {
-    if (isPrivileged && isEditMode) {
+    if (canEdit && isEditMode) {
       saveTacticBoard();
     }
     setSelection(!isEditMode);
@@ -177,7 +179,7 @@ const TacticBoardTopMenu = ({
           )}
 
           {/* ANIMATION BUTTON END */}
-          {isPrivileged && isEditMode && (
+          {canEdit && isEditMode && (
             <Tooltip
               title={t("TacticBoard:topMenu.pagination.tooltip_removePage")}
             >
@@ -210,7 +212,7 @@ const TacticBoardTopMenu = ({
             disabled={isTacticBoardLoading || isRecording || isAnimating}
             onChange={handleChange}
           />
-          {isPrivileged && isEditMode && (
+          {canEdit && isEditMode && (
             <Tooltip
               title={t("TacticBoard:topMenu.pagination.tooltip_addPage")}
             >
@@ -273,7 +275,7 @@ const TacticBoardTopMenu = ({
           </span>
         </Tooltip>
         {/* EDIT/SAVE BUTTON START */}
-        {isPrivileged && (
+        {canEdit && (
           <Tooltip
             title={t("TacticBoard:topMenu.isEditModeButton.tooltip", {
               context: isEditMode ? "editMode" : "viewMode",
@@ -299,7 +301,7 @@ const TacticBoardTopMenu = ({
             </span>
           </Tooltip>
         )}
-        {isPrivileged && (
+        {canDelete && (
           <Tooltip title={t("TacticBoard:topMenu.deleteButton.tooltip")}>
             <span>
               <ToggleButton

--- a/client/src/pages/TacticBoardProfile/TacticBoardInProfile.tsx
+++ b/client/src/pages/TacticBoardProfile/TacticBoardInProfile.tsx
@@ -25,7 +25,8 @@ import { TacticBoardProvider } from "../../contexts/tacticBoard";
 import { animateObjectsToTargets } from "../../contexts/tacticBoard/animation";
 import { useAuth } from "../../store/hooks";
 import useVideoRecording from "../../hooks/taticBoard/useVideoRecording";
-import { useGetAllTacticboardAccessUsersQuery } from "../../api/quadcoachApi/tacticboardApi";
+import { useCheckTacticboardAccessQuery } from "../../api/quadcoachApi/tacticboardApi";
+import { canEditResource } from "../../api/quadcoachApi/domain";
 export type TacticBoardInProfileProps = {
   tacticBoardId: string | undefined;
   sharedToken?: string;
@@ -52,7 +53,6 @@ const TacticBoardInProfile = ({
   const [isAnimating, setIsAnimating] = useState<boolean>(false);
 
   const [isFullScreen, setIsFullScreen] = useState<boolean>(false);
-  const [isPrivileged, setIsPrivileged] = useState<boolean>(false);
   const refFullScreenContainer = useRef<HTMLDivElement>(null);
   const {
     canvasFabricRef: canvasRef,
@@ -63,37 +63,13 @@ const TacticBoardInProfile = ({
 
   const { loadFromTacticPage: loadFromJson } = useTacticBoardData();
 
-  const { id: userId, roles: userRoles } = useAuth();
+  const { id: userId } = useAuth();
 
-  const { data: accessUsers } = useGetAllTacticboardAccessUsersQuery(
+  const { data: authorization } = useCheckTacticboardAccessQuery(
     tacticBoardId || "",
-    { skip: !tacticBoardId || !userId || userId === "" },
+    { skip: !tacticBoardId || !userId || Boolean(sharedToken) },
   );
-
-  useEffect(() => {
-    if (sharedToken) {
-      setIsPrivileged(false);
-      return;
-    }
-
-    if (
-      userId == tacticBoard?.user ||
-      userRoles.includes("Admin") ||
-      userRoles.includes("admin")
-    ) {
-      setIsPrivileged(true);
-    } else {
-      if (accessUsers) {
-        setIsPrivileged(
-          accessUsers.some((user) => {
-            return (
-              user.user._id.toString() === userId && user.access === "edit"
-            );
-          }),
-        );
-      }
-    }
-  }, [userId, tacticBoard, userRoles, accessUsers, sharedToken]);
+  const canEdit = !sharedToken && canEditResource(authorization);
 
   useEffect(() => {
     if (
@@ -379,7 +355,7 @@ const TacticBoardInProfile = ({
           </Tooltip>
         </SoftBox>
 
-        {isPrivileged && isEditMode && (
+        {canEdit && isEditMode && (
           <>
             <Tooltip
               title={t("TacticBoardProfile:topMenu.isEditModeButton.tooltip")}

--- a/client/src/pages/TacticBoardProfile/TacticBoardProfile.tsx
+++ b/client/src/pages/TacticBoardProfile/TacticBoardProfile.tsx
@@ -48,6 +48,7 @@ import {
   useGetTacticBoardQuery,
   useUpdateTacticBoardMetaMutation,
   useShareTacticBoardMutation,
+  useCheckTacticboardAccessQuery,
 } from "../../api/quadcoachApi/tacticboardApi";
 import { useParams, useNavigate } from "react-router-dom";
 import {
@@ -76,7 +77,11 @@ import {
   FormikProvider,
   useFormik,
 } from "formik";
-import { TacticBoardPartialId } from "../../api/quadcoachApi/domain";
+import {
+  canEditResource,
+  canManageResource,
+  TacticBoardPartialId,
+} from "../../api/quadcoachApi/domain";
 import AddTagDialog from "./AddTagDialog";
 import Footer from "../../components/Footer";
 import {
@@ -93,7 +98,6 @@ const TacticBoardProfile = () => {
   const { id: tacticBoardId } = useParams();
 
   const navigate = useNavigate();
-  const [isPrivileged, setIsPrivileged] = useState<boolean>(false);
   const [isFavorite, setIsFavorite] = useState<boolean>(false);
   const isUpMd = useMediaQuery((theme: Theme) => theme.breakpoints.up("md"));
   const [isEditMode, setIsEditMode] = useState<boolean>(false);
@@ -109,7 +113,7 @@ const TacticBoardProfile = () => {
   const copyHighlightTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
     null,
   );
-  const { id: userId, roles: userRoles } = useAuth();
+  const { id: userId } = useAuth();
 
   const {
     data: tacticBoard,
@@ -118,6 +122,12 @@ const TacticBoardProfile = () => {
   } = useGetTacticBoardQuery(tacticBoardId || "", {
     skip: tacticBoardId == null,
   });
+  const { data: authorization } = useCheckTacticboardAccessQuery(
+    tacticBoardId || "",
+    { skip: !tacticBoardId || !userId },
+  );
+  const canEdit = canEditResource(authorization);
+  const canManageResourceActions = canManageResource(authorization);
 
   const [
     updateTacticBoardMeta,
@@ -160,6 +170,7 @@ const TacticBoardProfile = () => {
 
   const { data: accessUsers } = useGetAllTacticboardAccessUsersQuery(
     tacticBoardId || "",
+    { skip: !tacticBoardId || !canManageResourceActions },
   );
 
   const [
@@ -220,31 +231,6 @@ const TacticBoardProfile = () => {
       }
     },
   });
-
-  useEffect(() => {
-    if (
-      tacticBoard?.user?.toString() === userId ||
-      userRoles.includes("Admin") ||
-      userRoles.includes("admin")
-    ) {
-      setIsPrivileged(true);
-    } else {
-      if (accessUsers) {
-        setIsPrivileged(
-          accessUsers.some((user) => {
-            return (
-              user.user._id.toString() === userId && user.access === "edit"
-            );
-          }),
-        );
-      }
-    }
-  }, [tacticBoard, userId, userRoles, accessUsers]);
-
-  const isCreator =
-    tacticBoard?.user?.toString() === userId ||
-    userRoles.includes("Admin") ||
-    userRoles.includes("admin");
 
   useEffect(() => {
     if (favoriteTacticboards) {
@@ -422,7 +408,7 @@ const TacticBoardProfile = () => {
     Boolean(userId) && userId !== "" && Boolean(tacticBoardId);
   const tacticBoardMenuActions: HeaderOverflowAction[] = [];
 
-  if (isPrivileged && tacticBoard.isPrivate) {
+  if (canEdit && tacticBoard.isPrivate) {
     tacticBoardMenuActions.push({
       key: "share",
       label: t(
@@ -446,7 +432,7 @@ const TacticBoardProfile = () => {
     });
   }
 
-  if (isPrivileged) {
+  if (canManageResourceActions) {
     tacticBoardMenuActions.push({
       key: "delete",
       label: t("TacticBoardProfile:menu.delete"),
@@ -510,7 +496,7 @@ const TacticBoardProfile = () => {
                   </IconButton>
                 </Tooltip>
               )}
-              {isPrivileged && (
+              {canEdit && (
                 <Tooltip title={t("TacticBoardProfile:editTacticBoardMeta")}>
                   <IconButton
                     onClick={() => {
@@ -569,7 +555,7 @@ const TacticBoardProfile = () => {
                 />
               </Tooltip>
             ),
-            isPrivileged && (
+            canEdit && (
               <Tooltip
                 key="edit"
                 title={t("TacticBoardProfile:editTacticBoardMeta")}
@@ -843,7 +829,7 @@ const TacticBoardProfile = () => {
                   </AccordionDetails>
                 </Accordion>
               )}
-              {isEditMode && isCreator && (
+              {isEditMode && canManageResourceActions && (
                 <Accordion defaultExpanded>
                   <AccordionSummary expandIcon={<ExpandMoreIcon />}>
                     {t("TacticBoardProfile:access.title")}

--- a/client/src/pages/exerciseApi.ts
+++ b/client/src/pages/exerciseApi.ts
@@ -1,7 +1,10 @@
 import type { TagDescription } from "@reduxjs/toolkit/query";
 import { quadcoachApi } from "../api";
 import { TagType } from "../api/enum";
-import { Exercise } from "../api/quadcoachApi/domain";
+import {
+  Exercise,
+  ResourceAuthorizationResponse,
+} from "../api/quadcoachApi/domain";
 
 export type GetExercisesRequest = {
   nameRegex?: string;
@@ -43,11 +46,6 @@ export type ExerciseAccessEntry = {
   exercise: string;
   access: AccessLevel;
   createdAt: string;
-};
-
-export type ExerciseAccessResponse = {
-  hasAccess: boolean;
-  type: "owner" | "admin" | "granted" | "public" | null;
 };
 
 export const exerciseApiSlice = quadcoachApi.injectEndpoints({
@@ -291,7 +289,7 @@ export const exerciseApiSlice = quadcoachApi.injectEndpoints({
             }, new Array<TagDescription<TagType>>())
           : [TagType.exercise, TagType.block],
     }),
-    checkExerciseAccess: builder.query<ExerciseAccessResponse, string>({
+    checkExerciseAccess: builder.query<ResourceAuthorizationResponse, string>({
       query: (exerciseId) => ({
         url: `/api/exercises/${exerciseId}/checkAccess`,
         method: "get",

--- a/client/src/pages/exerciseApi.ts
+++ b/client/src/pages/exerciseApi.ts
@@ -47,7 +47,7 @@ export type ExerciseAccessEntry = {
 
 export type ExerciseAccessResponse = {
   hasAccess: boolean;
-  type: "owner" | "admin" | "granted" | null;
+  type: "owner" | "admin" | "granted" | "public" | null;
 };
 
 export const exerciseApiSlice = quadcoachApi.injectEndpoints({

--- a/server/authorization/resourceAuthorization.ts
+++ b/server/authorization/resourceAuthorization.ts
@@ -1,0 +1,126 @@
+import ExerciseAccess from "../models/exerciseAccess";
+import PracticePlanAccess from "../models/practicePlanAccess";
+import TacticboardAccess from "../models/tacticboardAccess";
+
+export type ResourceType = "exercise" | "tacticBoard" | "practicePlan";
+
+export type ResourceAction = "view" | "edit" | "delete" | "manageAccess";
+
+export type AccessLevel = "view" | "edit";
+
+export interface ResourceAuthorizationActor {
+  id: string;
+  roles: string[];
+}
+
+export interface ResourceAuthorizationResource {
+  type: ResourceType;
+  id: string;
+  ownerId?: string;
+  isPrivate: boolean;
+}
+
+export interface ResourceAuthorizationRequest {
+  action: ResourceAction;
+  actor?: ResourceAuthorizationActor;
+  resource: ResourceAuthorizationResource;
+}
+
+export interface AccessGrantAdapter {
+  findAccessLevel(
+    userId: string,
+    resourceId: string,
+  ): Promise<AccessLevel | null>;
+}
+
+export type AccessGrantAdapters = Record<ResourceType, AccessGrantAdapter>;
+
+export type ResourceAuthorizationDecision =
+  | {
+      allowed: true;
+      basis: "owner" | "admin" | "public";
+    }
+  | {
+      allowed: true;
+      basis: "granted";
+      accessLevel: AccessLevel;
+    }
+  | {
+      allowed: false;
+      reason: "authenticationRequired" | "forbidden";
+    };
+
+export function createResourceAuthorization(
+  accessGrantAdapters: AccessGrantAdapters,
+): (
+  request: ResourceAuthorizationRequest,
+) => Promise<ResourceAuthorizationDecision> {
+  return async function decide(
+    request: ResourceAuthorizationRequest,
+  ): Promise<ResourceAuthorizationDecision> {
+    const { action, actor, resource } = request;
+    const isPublic = resource.type === "exercise" || !resource.isPrivate;
+
+    if (actor?.id === resource.ownerId) {
+      return { allowed: true, basis: "owner" };
+    }
+
+    if (actor?.roles.some((role) => role.toLowerCase() === "admin")) {
+      return { allowed: true, basis: "admin" };
+    }
+
+    if (actor && (action === "view" || action === "edit")) {
+      const accessLevel = await accessGrantAdapters[
+        resource.type
+      ].findAccessLevel(actor.id, resource.id);
+
+      if (
+        accessLevel === "edit" ||
+        (accessLevel === "view" && action === "view")
+      ) {
+        return { allowed: true, basis: "granted", accessLevel };
+      }
+    }
+
+    if (action === "view" && isPublic) {
+      return { allowed: true, basis: "public" };
+    }
+
+    return actor
+      ? { allowed: false, reason: "forbidden" }
+      : { allowed: false, reason: "authenticationRequired" };
+  };
+}
+
+const accessGrantAdapters: AccessGrantAdapters = {
+  exercise: {
+    async findAccessLevel(userId, resourceId) {
+      const grant = await ExerciseAccess.findOne({
+        user: userId,
+        exercise: resourceId,
+      }).select("access");
+      return grant?.access ?? null;
+    },
+  },
+  tacticBoard: {
+    async findAccessLevel(userId, resourceId) {
+      const grant = await TacticboardAccess.findOne({
+        user: userId,
+        tacticboard: resourceId,
+      }).select("access");
+      return grant?.access ?? null;
+    },
+  },
+  practicePlan: {
+    async findAccessLevel(userId, resourceId) {
+      const grant = await PracticePlanAccess.findOne({
+        user: userId,
+        practicePlan: resourceId,
+      }).select("access");
+      return grant?.access ?? null;
+    },
+  },
+};
+
+export const decideResourceAuthorization =
+  createResourceAuthorization(accessGrantAdapters);

--- a/server/authorization/resourceAuthorization.ts
+++ b/server/authorization/resourceAuthorization.ts
@@ -20,6 +20,50 @@ export interface ResourceAuthorizationResource {
   isPrivate: boolean;
 }
 
+interface OwnedResource {
+  user?: { toString(): string } | null;
+}
+
+interface PrivateResource extends OwnedResource {
+  isPrivate?: boolean | null;
+}
+
+export const authorizationResourceFor = {
+  exercise(
+    id: string,
+    resource: OwnedResource,
+  ): ResourceAuthorizationResource {
+    return {
+      type: "exercise",
+      id,
+      ownerId: resource.user?.toString(),
+      isPrivate: false,
+    };
+  },
+  tacticBoard(
+    id: string,
+    resource: PrivateResource,
+  ): ResourceAuthorizationResource {
+    return {
+      type: "tacticBoard",
+      id,
+      ownerId: resource.user?.toString(),
+      isPrivate: resource.isPrivate ?? false,
+    };
+  },
+  practicePlan(
+    id: string,
+    resource: PrivateResource,
+  ): ResourceAuthorizationResource {
+    return {
+      type: "practicePlan",
+      id,
+      ownerId: resource.user?.toString(),
+      isPrivate: resource.isPrivate ?? false,
+    };
+  },
+};
+
 export interface ResourceAuthorizationRequest {
   action: ResourceAction;
   actor?: ResourceAuthorizationActor;

--- a/server/controllers/exerciseController.ts
+++ b/server/controllers/exerciseController.ts
@@ -10,7 +10,9 @@ import TacticBoard from "../models/tacticboard";
 import {
   getResourceAuthorization,
   requireResourceAuthorization,
+  serializeResourceAuthorizationDecision,
 } from "./helpers/requireResourceAuthorization";
+import { authorizationResourceFor } from "../authorization/resourceAuthorization";
 
 interface RequestWithUser extends Request {
   UserInfo?: {
@@ -224,12 +226,7 @@ export const updateById = asyncHandler(
           !(await requireResourceAuthorization(
             req,
             res,
-            {
-              type: "exercise",
-              id: req.params.id,
-              ownerId: findResult.user?.toString(),
-              isPrivate: false,
-            },
+            authorizationResourceFor.exercise(req.params.id, findResult),
             "edit",
           ))
         ) {
@@ -253,9 +250,13 @@ export const updateById = asyncHandler(
           return;
         }
 
+        const updates = { ...(req.body as Record<string, unknown>) };
+        delete updates.user;
+        delete updates.owner;
+
         const result = await Exercise.updateOne(
           { _id: req.params.id },
-          { $set: req.body }
+          { $set: updates }
         );
         res.send(result);
       } else {
@@ -279,12 +280,7 @@ export const deleteById = asyncHandler(
           !(await requireResourceAuthorization(
             req,
             res,
-            {
-              type: "exercise",
-              id: req.params.id,
-              ownerId: findResult.user?.toString(),
-              isPrivate: false,
-            },
+            authorizationResourceFor.exercise(req.params.id, findResult),
             "delete",
           ))
         ) {
@@ -378,12 +374,7 @@ export const setAccess = asyncHandler(
       !(await requireResourceAuthorization(
         req,
         res,
-        {
-          type: "exercise",
-          id: req.params.id,
-          ownerId: exercise.user?.toString(),
-          isPrivate: false,
-        },
+        authorizationResourceFor.exercise(req.params.id, exercise),
         "manageAccess",
       ))
     ) {
@@ -444,12 +435,7 @@ export const deleteAccess = asyncHandler(
       !(await requireResourceAuthorization(
         req,
         res,
-        {
-          type: "exercise",
-          id: req.params.id,
-          ownerId: exercise.user?.toString(),
-          isPrivate: false,
-        },
+        authorizationResourceFor.exercise(req.params.id, exercise),
         "manageAccess",
       ))
     ) {
@@ -499,26 +485,11 @@ export const checkAccess = asyncHandler(
 
     const decision = await getResourceAuthorization(
       req,
-      {
-        type: "exercise",
-        id: req.params.id,
-        ownerId: exercise.user?.toString(),
-        isPrivate: false,
-      },
+      authorizationResourceFor.exercise(req.params.id, exercise),
       "view",
     );
 
-    res.json({
-      hasAccess: decision.allowed,
-      type: decision.allowed ? decision.basis : null,
-      level:
-        decision.allowed && decision.basis === "granted"
-          ? decision.accessLevel
-          : decision.allowed &&
-              (decision.basis === "owner" || decision.basis === "admin")
-            ? "edit"
-            : null,
-    });
+    res.json(serializeResourceAuthorizationDecision(decision));
   }
 );
 
@@ -541,12 +512,7 @@ export const getAllAccessUsers = asyncHandler(
       !(await requireResourceAuthorization(
         req,
         res,
-        {
-          type: "exercise",
-          id: req.params.id,
-          ownerId: exercise.user?.toString(),
-          isPrivate: false,
-        },
+        authorizationResourceFor.exercise(req.params.id, exercise),
         "manageAccess",
       ))
     ) {
@@ -595,12 +561,7 @@ export const shareExercise = asyncHandler(
       !(await requireResourceAuthorization(
         req,
         res,
-        {
-          type: "exercise",
-          id: req.params.id,
-          ownerId: exercise.user?.toString(),
-          isPrivate: false,
-        },
+        authorizationResourceFor.exercise(req.params.id, exercise),
         "manageAccess",
       ))
     ) {

--- a/server/controllers/exerciseController.ts
+++ b/server/controllers/exerciseController.ts
@@ -7,6 +7,10 @@ import ExerciseAccess from "../models/exerciseAccess";
 import User from "../models/user";
 import { PracticePlan } from "../models/practicePlan";
 import TacticBoard from "../models/tacticboard";
+import {
+  getResourceAuthorization,
+  requireResourceAuthorization,
+} from "./helpers/requireResourceAuthorization";
 
 interface RequestWithUser extends Request {
   UserInfo?: {
@@ -216,22 +220,19 @@ export const updateById = asyncHandler(
     if (mongoose.isValidObjectId(req.params.id)) {
       const findResult = await Exercise.findOne({ _id: req.params.id });
       if (findResult) {
-        if (!req.UserInfo?.id) {
-          res.status(401).json({ message: "Unauthorized" });
-          return;
-        }
-
-        const accessUser = await ExerciseAccess.findOne({
-          user: req.UserInfo.id,
-          exercise: req.params.id,
-        });
-        const hasAccess =
-          findResult.user?.toString() === req.UserInfo.id ||
-          req.UserInfo.roles?.includes("Admin") ||
-          req.UserInfo.roles?.includes("admin") ||
-          (accessUser && accessUser.access == "edit");
-        if (!hasAccess) {
-          res.status(403).json({ message: "Forbidden" });
+        if (
+          !(await requireResourceAuthorization(
+            req,
+            res,
+            {
+              type: "exercise",
+              id: req.params.id,
+              ownerId: findResult.user?.toString(),
+              isPrivate: false,
+            },
+            "edit",
+          ))
+        ) {
           return;
         }
 
@@ -274,22 +275,19 @@ export const deleteById = asyncHandler(
     if (mongoose.isValidObjectId(req.params.id)) {
       const findResult = await Exercise.findOne({ _id: req.params.id });
       if (findResult) {
-        if (!req.UserInfo?.id) {
-          res.status(401).json({ message: "Unauthorized" });
-          return;
-        }
-        const accessUser = await ExerciseAccess.findOne({
-          user: req.UserInfo.id,
-          exercise: req.params.id,
-        });
-        const hasAccess =
-          findResult.user?.toString() === req.UserInfo.id ||
-          req.UserInfo.roles?.includes("Admin") ||
-          req.UserInfo.roles?.includes("admin") ||
-          (accessUser && accessUser.access == "edit");
-
-        if (!hasAccess) {
-          res.status(403).json({ message: "Forbidden" });
+        if (
+          !(await requireResourceAuthorization(
+            req,
+            res,
+            {
+              type: "exercise",
+              id: req.params.id,
+              ownerId: findResult.user?.toString(),
+              isPrivate: false,
+            },
+            "delete",
+          ))
+        ) {
           return;
         }
 
@@ -376,23 +374,19 @@ export const setAccess = asyncHandler(
       return;
     }
 
-    // Check if user has access to grant access
-    if (!req.UserInfo?.id) {
-      res.status(401).json({ message: "Unauthorized" });
-      return;
-    }
-
-    const hasAccess =
-      exercise.user?.toString() === req.UserInfo.id ||
-      req.UserInfo.roles?.includes("Admin") ||
-      req.UserInfo.roles?.includes("admin") ||
-      (await ExerciseAccess.exists({
-        user: req.UserInfo.id,
-        exercise: req.params.id,
-      }));
-
-    if (!hasAccess) {
-      res.status(403).json({ message: "Forbidden" });
+    if (
+      !(await requireResourceAuthorization(
+        req,
+        res,
+        {
+          type: "exercise",
+          id: req.params.id,
+          ownerId: exercise.user?.toString(),
+          isPrivate: false,
+        },
+        "manageAccess",
+      ))
+    ) {
       return;
     }
 
@@ -446,23 +440,19 @@ export const deleteAccess = asyncHandler(
       return;
     }
 
-    // Check if user has access to remove access
-    if (!req.UserInfo?.id) {
-      res.status(401).json({ message: "Unauthorized" });
-      return;
-    }
-
-    const hasAccess =
-      exercise.user?.toString() === req.UserInfo.id ||
-      req.UserInfo.roles?.includes("Admin") ||
-      req.UserInfo.roles?.includes("admin") ||
-      (await ExerciseAccess.exists({
-        user: req.UserInfo.id,
-        exercise: req.params.id,
-      }));
-
-    if (!hasAccess) {
-      res.status(403).json({ message: "Forbidden" });
+    if (
+      !(await requireResourceAuthorization(
+        req,
+        res,
+        {
+          type: "exercise",
+          id: req.params.id,
+          ownerId: exercise.user?.toString(),
+          isPrivate: false,
+        },
+        "manageAccess",
+      ))
+    ) {
       return;
     }
 
@@ -507,43 +497,27 @@ export const checkAccess = asyncHandler(
       return;
     }
 
-    // Check if user is the owner
-    if (exercise.user?.toString() === req.UserInfo.id) {
-      res.json({ hasAccess: true, type: "owner" });
-      return;
-    }
-
-    // Check if user is an admin
-    if (
-      req.UserInfo.roles?.includes("Admin") ||
-      req.UserInfo.roles?.includes("admin")
-    ) {
-      res.json({ hasAccess: true, type: "admin" });
-      return;
-    }
-
-    // Check if user has been granted access
-    const accessEntry = await ExerciseAccess.findOne({
-      user: req.UserInfo.id,
-      exercise: req.params.id,
-    });
-
-    if (accessEntry) {
-      res.json({ hasAccess: true, type: "granted" });
-      return;
-    }
-
-    res.json({ hasAccess: false, type: null });
-
-    // Check if user has been granted access
-    const access = await ExerciseAccess.findOne({
-      user: req.UserInfo.id,
-      exercise: req.params.id,
-    });
+    const decision = await getResourceAuthorization(
+      req,
+      {
+        type: "exercise",
+        id: req.params.id,
+        ownerId: exercise.user?.toString(),
+        isPrivate: false,
+      },
+      "view",
+    );
 
     res.json({
-      hasAccess: !!access,
-      type: access ? "granted" : null,
+      hasAccess: decision.allowed,
+      type: decision.allowed ? decision.basis : null,
+      level:
+        decision.allowed && decision.basis === "granted"
+          ? decision.accessLevel
+          : decision.allowed &&
+              (decision.basis === "owner" || decision.basis === "admin")
+            ? "edit"
+            : null,
     });
   }
 );
@@ -563,23 +537,19 @@ export const getAllAccessUsers = asyncHandler(
       res.status(404).json({ message: "Exercise not found" });
       return;
     }
-    // Check if user has access
-    if (!req.UserInfo?.id) {
-      res.status(401).json({ message: "Unauthorized" });
-      return;
-    }
-
-    const hasAccess =
-      exercise.user?.toString() === req.UserInfo.id ||
-      req.UserInfo.roles?.includes("Admin") ||
-      req.UserInfo.roles?.includes("admin") ||
-      (await ExerciseAccess.exists({
-        user: req.UserInfo.id,
-        exercise: req.params.id,
-      }));
-
-    if (!hasAccess) {
-      res.status(403).json({ message: "Forbidden" });
+    if (
+      !(await requireResourceAuthorization(
+        req,
+        res,
+        {
+          type: "exercise",
+          id: req.params.id,
+          ownerId: exercise.user?.toString(),
+          isPrivate: false,
+        },
+        "manageAccess",
+      ))
+    ) {
       return;
     }
 
@@ -621,13 +591,19 @@ export const shareExercise = asyncHandler(
       return;
     }
 
-    const isOwner = exercise.user?.toString() === req.UserInfo.id;
-    const isAdmin = req.UserInfo.roles?.some(
-      (role) => role.toLowerCase() === "admin"
-    );
-
-    if (!isOwner && !isAdmin) {
-      res.status(403).json({ message: "Forbidden" });
+    if (
+      !(await requireResourceAuthorization(
+        req,
+        res,
+        {
+          type: "exercise",
+          id: req.params.id,
+          ownerId: exercise.user?.toString(),
+          isPrivate: false,
+        },
+        "manageAccess",
+      ))
+    ) {
       return;
     }
 

--- a/server/controllers/helpers/requireResourceAuthorization.ts
+++ b/server/controllers/helpers/requireResourceAuthorization.ts
@@ -1,0 +1,46 @@
+import { Request, Response } from "express";
+import {
+  decideResourceAuthorization,
+  ResourceAction,
+  ResourceAuthorizationDecision,
+  ResourceAuthorizationResource,
+} from "../../authorization/resourceAuthorization";
+
+interface RequestWithUser extends Request {
+  UserInfo?: {
+    id?: string;
+    roles?: string[];
+  };
+}
+
+export const getResourceAuthorization = async (
+  req: RequestWithUser,
+  resource: ResourceAuthorizationResource,
+  action: ResourceAction,
+): Promise<ResourceAuthorizationDecision> =>
+  decideResourceAuthorization({
+    action,
+    actor: req.UserInfo?.id
+      ? { id: req.UserInfo.id, roles: req.UserInfo.roles ?? [] }
+      : undefined,
+    resource,
+  });
+
+export const requireResourceAuthorization = async (
+  req: RequestWithUser,
+  res: Response,
+  resource: ResourceAuthorizationResource,
+  action: ResourceAction,
+): Promise<boolean> => {
+  const decision = await getResourceAuthorization(req, resource, action);
+  if (decision.allowed) {
+    return true;
+  }
+
+  const status =
+    decision.reason === "authenticationRequired" ? 401 : 403;
+  res.status(status).json({
+    message: status === 401 ? "Unauthorized" : "Forbidden",
+  });
+  return false;
+};

--- a/server/controllers/helpers/requireResourceAuthorization.ts
+++ b/server/controllers/helpers/requireResourceAuthorization.ts
@@ -26,6 +26,20 @@ export const getResourceAuthorization = async (
     resource,
   });
 
+export const serializeResourceAuthorizationDecision = (
+  decision: ResourceAuthorizationDecision,
+) => ({
+  hasAccess: decision.allowed,
+  type: decision.allowed ? decision.basis : null,
+  level:
+    decision.allowed && decision.basis === "granted"
+      ? decision.accessLevel
+      : decision.allowed &&
+          (decision.basis === "owner" || decision.basis === "admin")
+        ? "edit"
+        : null,
+});
+
 export const requireResourceAuthorization = async (
   req: RequestWithUser,
   res: Response,

--- a/server/controllers/practicePlanController.ts
+++ b/server/controllers/practicePlanController.ts
@@ -11,7 +11,12 @@ import {
 } from "./helpers/practicePlanValidation";
 import User from "../models/user";
 import { logEvents } from "../middleware/logger";
-import { requireResourceAuthorization } from "./helpers/requireResourceAuthorization";
+import {
+  getResourceAuthorization,
+  requireResourceAuthorization,
+  serializeResourceAuthorizationDecision,
+} from "./helpers/requireResourceAuthorization";
+import { authorizationResourceFor } from "../authorization/resourceAuthorization";
 
 interface RequestWithUser extends Request {
   UserInfo?: {
@@ -165,12 +170,7 @@ export const getPracticePlan = async (req: RequestWithUser, res: Response) => {
         !(await requireResourceAuthorization(
           req,
           res,
-          {
-            type: "practicePlan",
-            id: req.params.id,
-            ownerId: result.user?.toString(),
-            isPrivate: result.isPrivate,
-          },
+          authorizationResourceFor.practicePlan(req.params.id, result),
           "view",
         ))
       ) {
@@ -202,12 +202,7 @@ export const patchPracticePlan = async (
         !(await requireResourceAuthorization(
           req,
           res,
-          {
-            type: "practicePlan",
-            id: req.params.id,
-            ownerId: findResult.user?.toString(),
-            isPrivate: findResult.isPrivate,
-          },
+          authorizationResourceFor.practicePlan(req.params.id, findResult),
           "edit",
         ))
       ) {
@@ -267,12 +262,7 @@ export const deletePracticePlan = async (
         !(await requireResourceAuthorization(
           req,
           res,
-          {
-            type: "practicePlan",
-            id: req.params.id,
-            ownerId: findResult.user?.toString(),
-            isPrivate: findResult.isPrivate,
-          },
+          authorizationResourceFor.practicePlan(req.params.id, findResult),
           "delete",
         ))
       ) {
@@ -294,6 +284,29 @@ export const deletePracticePlan = async (
   }
 };
 
+export const checkAccess = asyncHandler(
+  async (req: RequestWithUser, res: Response) => {
+    if (!mongoose.isValidObjectId(req.params.id)) {
+      res.status(400).json({ message: "Invalid practice plan ID" });
+      return;
+    }
+
+    const practicePlan = await PracticePlan.findById(req.params.id);
+    if (!practicePlan) {
+      res.status(404).json({ message: "Practice Plan not found" });
+      return;
+    }
+
+    const decision = await getResourceAuthorization(
+      req,
+      authorizationResourceFor.practicePlan(req.params.id, practicePlan),
+      "view",
+    );
+
+    res.json(serializeResourceAuthorizationDecision(decision));
+  },
+);
+
 // @desc    Get all users who have access to a practice plan
 // @route   GET /api/practice-plans/:id/access
 // @access  Private - Users with access
@@ -314,12 +327,7 @@ export const getAllAccessUsers = asyncHandler(
       !(await requireResourceAuthorization(
         req,
         res,
-        {
-          type: "practicePlan",
-          id: req.params.id,
-          ownerId: practicePlan.user?.toString(),
-          isPrivate: practicePlan.isPrivate,
-        },
+        authorizationResourceFor.practicePlan(req.params.id, practicePlan),
         "manageAccess",
       ))
     ) {
@@ -354,12 +362,7 @@ export const setAccess = asyncHandler(
       !(await requireResourceAuthorization(
         req,
         res,
-        {
-          type: "practicePlan",
-          id: req.params.id,
-          ownerId: practicePlan.user?.toString(),
-          isPrivate: practicePlan.isPrivate,
-        },
+        authorizationResourceFor.practicePlan(req.params.id, practicePlan),
         "manageAccess",
       ))
     ) {
@@ -418,12 +421,7 @@ export const deleteAccess = asyncHandler(
       !(await requireResourceAuthorization(
         req,
         res,
-        {
-          type: "practicePlan",
-          id: req.params.id,
-          ownerId: practicePlan.user?.toString(),
-          isPrivate: practicePlan.isPrivate,
-        },
+        authorizationResourceFor.practicePlan(req.params.id, practicePlan),
         "manageAccess",
       ))
     ) {
@@ -481,12 +479,7 @@ export const sharePracticePlan = asyncHandler(
       !(await requireResourceAuthorization(
         req,
         res,
-        {
-          type: "practicePlan",
-          id: req.params.id,
-          ownerId: practicePlan.user?.toString(),
-          isPrivate: practicePlan.isPrivate,
-        },
+        authorizationResourceFor.practicePlan(req.params.id, practicePlan),
         "manageAccess",
       ))
     ) {
@@ -571,12 +564,7 @@ export const createShareLink = asyncHandler(
       !(await requireResourceAuthorization(
         req,
         res,
-        {
-          type: "practicePlan",
-          id: req.params.id,
-          ownerId: practicePlan.user?.toString(),
-          isPrivate: practicePlan.isPrivate,
-        },
+        authorizationResourceFor.practicePlan(req.params.id, practicePlan),
         "edit",
       ))
     ) {
@@ -628,12 +616,7 @@ export const deleteShareLink = asyncHandler(
       !(await requireResourceAuthorization(
         req,
         res,
-        {
-          type: "practicePlan",
-          id: req.params.id,
-          ownerId: practicePlan.user?.toString(),
-          isPrivate: practicePlan.isPrivate,
-        },
+        authorizationResourceFor.practicePlan(req.params.id, practicePlan),
         "edit",
       ))
     ) {

--- a/server/controllers/practicePlanController.ts
+++ b/server/controllers/practicePlanController.ts
@@ -11,6 +11,7 @@ import {
 } from "./helpers/practicePlanValidation";
 import User from "../models/user";
 import { logEvents } from "../middleware/logger";
+import { requireResourceAuthorization } from "./helpers/requireResourceAuthorization";
 
 interface RequestWithUser extends Request {
   UserInfo?: {
@@ -160,28 +161,20 @@ export const getPracticePlan = async (req: RequestWithUser, res: Response) => {
     }
     const result = await PracticePlan.findOne({ _id: req.params.id });
     if (result) {
-      // Check if the practice plan is private
-      if (result.isPrivate && result.user) {
-        const userId = req.UserInfo?.id;
-        const isOwner =
-          userId && userId !== "" && userId === result.user.toString();
-        const isAdmin =
-          req.UserInfo?.roles?.includes("Admin") ||
-          req.UserInfo?.roles?.includes("admin");
-
-        // Check if user has shared access (only if user is authenticated)
-        const hasSharedAccess =
-          userId && userId !== ""
-            ? await PracticePlanAccess.exists({
-                user: userId,
-                practicePlan: req.params.id,
-              })
-            : false;
-
-        if (!isOwner && !isAdmin && !hasSharedAccess) {
-          res.status(403).json({ message: "Forbidden" });
-          return;
-        }
+      if (
+        !(await requireResourceAuthorization(
+          req,
+          res,
+          {
+            type: "practicePlan",
+            id: req.params.id,
+            ownerId: result.user?.toString(),
+            isPrivate: result.isPrivate,
+          },
+          "view",
+        ))
+      ) {
+        return;
       }
 
       res.send(result);
@@ -205,22 +198,19 @@ export const patchPracticePlan = async (
 
     const findResult = await PracticePlan.findOne({ _id: req.params.id });
     if (findResult) {
-      if (!req.UserInfo?.id) {
-        res.status(401).json({ message: "Unauthorized" });
-        return;
-      }
-      const accessUser = await PracticePlanAccess.findOne({
-        user: req.UserInfo.id,
-        practicePlan: req.params.id,
-      });
-      const hasAccess =
-        findResult.user?.toString() === req.UserInfo.id ||
-        req.UserInfo.roles?.includes("Admin") ||
-        req.UserInfo.roles?.includes("admin") ||
-        (accessUser && accessUser.access == "edit");
-
-      if (!hasAccess) {
-        res.status(403).json({ message: "Forbidden" });
+      if (
+        !(await requireResourceAuthorization(
+          req,
+          res,
+          {
+            type: "practicePlan",
+            id: req.params.id,
+            ownerId: findResult.user?.toString(),
+            isPrivate: findResult.isPrivate,
+          },
+          "edit",
+        ))
+      ) {
         return;
       }
 
@@ -273,22 +263,19 @@ export const deletePracticePlan = async (
     const findResult = await PracticePlan.findOne({ _id: req.params.id });
 
     if (findResult) {
-      // Check permissions
-      if (!req.UserInfo?.id) {
-        res.status(401).json({ message: "Unauthorized" });
-        return;
-      }
-      const accessUser = await PracticePlanAccess.findOne({
-        user: req.UserInfo.id,
-        practicePlan: req.params.id,
-      });
-      const hasAccess =
-        findResult.user?.toString() === req.UserInfo.id ||
-        req.UserInfo.roles?.includes("Admin") ||
-        req.UserInfo.roles?.includes("admin");
-
-      if (!hasAccess) {
-        res.status(403).json({ message: "Forbidden" });
+      if (
+        !(await requireResourceAuthorization(
+          req,
+          res,
+          {
+            type: "practicePlan",
+            id: req.params.id,
+            ownerId: findResult.user?.toString(),
+            isPrivate: findResult.isPrivate,
+          },
+          "delete",
+        ))
+      ) {
         return;
       }
 
@@ -323,23 +310,19 @@ export const getAllAccessUsers = asyncHandler(
       return;
     }
 
-    // Check if user has access to view access list
-    if (!req.UserInfo?.id) {
-      res.status(401).json({ message: "Unauthorized" });
-      return;
-    }
-
-    const hasAccess =
-      practicePlan.user?.toString() === req.UserInfo.id ||
-      req.UserInfo.roles?.includes("Admin") ||
-      req.UserInfo.roles?.includes("admin") ||
-      (await PracticePlanAccess.exists({
-        user: req.UserInfo.id,
-        practicePlan: req.params.id,
-      }));
-
-    if (!hasAccess) {
-      res.status(403).json({ message: "Forbidden" });
+    if (
+      !(await requireResourceAuthorization(
+        req,
+        res,
+        {
+          type: "practicePlan",
+          id: req.params.id,
+          ownerId: practicePlan.user?.toString(),
+          isPrivate: practicePlan.isPrivate,
+        },
+        "manageAccess",
+      ))
+    ) {
       return;
     }
 
@@ -367,21 +350,19 @@ export const setAccess = asyncHandler(
       return;
     }
 
-    // Check if user is the creator/owner or admin (only they can grant access)
-    if (!req.UserInfo?.id) {
-      res.status(401).json({ message: "Unauthorized" });
-      return;
-    }
-
-    const isCreator =
-      practicePlan.user?.toString() === req.UserInfo.id ||
-      req.UserInfo.roles?.includes("Admin") ||
-      req.UserInfo.roles?.includes("admin");
-
-    if (!isCreator) {
-      res
-        .status(403)
-        .json({ message: "Only the creator can modify access settings" });
+    if (
+      !(await requireResourceAuthorization(
+        req,
+        res,
+        {
+          type: "practicePlan",
+          id: req.params.id,
+          ownerId: practicePlan.user?.toString(),
+          isPrivate: practicePlan.isPrivate,
+        },
+        "manageAccess",
+      ))
+    ) {
       return;
     }
 
@@ -433,21 +414,19 @@ export const deleteAccess = asyncHandler(
       return;
     }
 
-    // Check if user is the creator/owner or admin (only they can remove access)
-    if (!req.UserInfo?.id) {
-      res.status(401).json({ message: "Unauthorized" });
-      return;
-    }
-
-    const isCreator =
-      practicePlan.user?.toString() === req.UserInfo.id ||
-      req.UserInfo.roles?.includes("Admin") ||
-      req.UserInfo.roles?.includes("admin");
-
-    if (!isCreator) {
-      res
-        .status(403)
-        .json({ message: "Only the creator can modify access settings" });
+    if (
+      !(await requireResourceAuthorization(
+        req,
+        res,
+        {
+          type: "practicePlan",
+          id: req.params.id,
+          ownerId: practicePlan.user?.toString(),
+          isPrivate: practicePlan.isPrivate,
+        },
+        "manageAccess",
+      ))
+    ) {
       return;
     }
 
@@ -498,13 +477,19 @@ export const sharePracticePlan = asyncHandler(
       return;
     }
 
-    const isOwner = practicePlan.user?.toString() === req.UserInfo.id;
-    const isAdmin = req.UserInfo.roles?.some(
-      (role) => role.toLowerCase() === "admin",
-    );
-
-    if (!isOwner && !isAdmin) {
-      res.status(403).json({ message: "Forbidden" });
+    if (
+      !(await requireResourceAuthorization(
+        req,
+        res,
+        {
+          type: "practicePlan",
+          id: req.params.id,
+          ownerId: practicePlan.user?.toString(),
+          isPrivate: practicePlan.isPrivate,
+        },
+        "manageAccess",
+      ))
+    ) {
       return;
     }
 
@@ -582,19 +567,19 @@ export const createShareLink = asyncHandler(
       return;
     }
 
-    const accessUser = await PracticePlanAccess.findOne({
-      user: req.UserInfo.id,
-      practicePlan: req.params.id,
-    });
-
-    const hasEditAccess =
-      practicePlan.user?.toString() === req.UserInfo.id ||
-      req.UserInfo.roles?.includes("Admin") ||
-      req.UserInfo.roles?.includes("admin") ||
-      (accessUser && accessUser.access === "edit");
-
-    if (!hasEditAccess) {
-      res.status(403).json({ message: "Forbidden" });
+    if (
+      !(await requireResourceAuthorization(
+        req,
+        res,
+        {
+          type: "practicePlan",
+          id: req.params.id,
+          ownerId: practicePlan.user?.toString(),
+          isPrivate: practicePlan.isPrivate,
+        },
+        "edit",
+      ))
+    ) {
       return;
     }
     try {
@@ -639,19 +624,19 @@ export const deleteShareLink = asyncHandler(
       return;
     }
 
-    const accessUser = await PracticePlanAccess.findOne({
-      user: req.UserInfo.id,
-      practicePlan: req.params.id,
-    });
-
-    const hasEditAccess =
-      practicePlan.user?.toString() === req.UserInfo.id ||
-      req.UserInfo.roles?.includes("Admin") ||
-      req.UserInfo.roles?.includes("admin") ||
-      (accessUser && accessUser.access === "edit");
-
-    if (!hasEditAccess) {
-      res.status(403).json({ message: "Forbidden" });
+    if (
+      !(await requireResourceAuthorization(
+        req,
+        res,
+        {
+          type: "practicePlan",
+          id: req.params.id,
+          ownerId: practicePlan.user?.toString(),
+          isPrivate: practicePlan.isPrivate,
+        },
+        "edit",
+      ))
+    ) {
       return;
     }
 

--- a/server/controllers/tacticboardController.ts
+++ b/server/controllers/tacticboardController.ts
@@ -8,6 +8,10 @@ import TacticboardFav from "../models/tacticboardFav";
 import TacticboardAccess from "../models/tacticboardAccess";
 import User from "../models/user";
 import { logEvents } from "../middleware/logger";
+import {
+  getResourceAuthorization,
+  requireResourceAuthorization,
+} from "./helpers/requireResourceAuthorization";
 
 interface UserInfo {
   id?: string;
@@ -223,28 +227,20 @@ export const getById = asyncHandler(
     if (mongoose.isValidObjectId(req.params.id)) {
       const result = await TacticBoard.findOne({ _id: req.params.id });
       if (result) {
-        // Check if the tacticboard is private
-        if (result.isPrivate && result.user) {
-          const userId = req.UserInfo?.id;
-          const isOwner =
-            userId && userId !== "" && userId === result.user.toString();
-          const isAdmin =
-            req.UserInfo?.roles?.includes("Admin") ||
-            req.UserInfo?.roles?.includes("admin");
-
-          // Check if user has shared access (only if user is authenticated)
-          const hasSharedAccess =
-            userId && userId !== ""
-              ? await TacticboardAccess.exists({
-                  user: userId,
-                  tacticboard: req.params.id,
-                })
-              : false;
-
-          if (!isOwner && !isAdmin && !hasSharedAccess) {
-            res.status(403).json({ message: "Forbidden" });
-            return;
-          }
+        if (
+          !(await requireResourceAuthorization(
+            req,
+            res,
+            {
+              type: "tacticBoard",
+              id: req.params.id,
+              ownerId: result.user?.toString(),
+              isPrivate: result.isPrivate ?? false,
+            },
+            "view",
+          ))
+        ) {
+          return;
         }
 
         res.send(result);
@@ -288,22 +284,19 @@ export const updateById = asyncHandler(
     if (mongoose.isValidObjectId(req.params.id)) {
       const findResult = await TacticBoard.findOne({ _id: req.params.id });
       if (findResult) {
-        if (!req.UserInfo?.id) {
-          res.status(401).json({ message: "Unauthorized" });
-          return;
-        }
-        const accessUser = await TacticboardAccess.findOne({
-          user: req.UserInfo.id,
-          tacticboard: req.params.id,
-        });
-        const hasAccess =
-          findResult.user?.toString() === req.UserInfo.id ||
-          req.UserInfo.roles?.includes("Admin") ||
-          req.UserInfo.roles?.includes("admin") ||
-          (accessUser && accessUser.access == "edit");
-
-        if (!hasAccess) {
-          res.status(403).json({ message: "Forbidden" });
+        if (
+          !(await requireResourceAuthorization(
+            req,
+            res,
+            {
+              type: "tacticBoard",
+              id: req.params.id,
+              ownerId: findResult.user?.toString(),
+              isPrivate: findResult.isPrivate ?? false,
+            },
+            "edit",
+          ))
+        ) {
           return;
         }
 
@@ -337,22 +330,19 @@ export const updatePageById = asyncHandler(
     ) {
       const findResult = await TacticBoard.findOne({ _id: req.params.id });
       if (findResult) {
-        if (!req.UserInfo?.id) {
-          res.status(401).json({ message: "Unauthorized" });
-          return;
-        }
-        const accessUser = await TacticboardAccess.findOne({
-          user: req.UserInfo.id,
-          tacticboard: req.params.id,
-        });
-        const hasAccess =
-          findResult.user?.toString() === req.UserInfo.id ||
-          req.UserInfo.roles?.includes("Admin") ||
-          req.UserInfo.roles?.includes("admin") ||
-          (accessUser && accessUser.access == "edit");
-
-        if (!hasAccess) {
-          res.status(403).json({ message: "Forbidden" });
+        if (
+          !(await requireResourceAuthorization(
+            req,
+            res,
+            {
+              type: "tacticBoard",
+              id: tacticBoardId,
+              ownerId: findResult.user?.toString(),
+              isPrivate: findResult.isPrivate ?? false,
+            },
+            "edit",
+          ))
+        ) {
           return;
         }
 
@@ -392,22 +382,19 @@ export const updateMetaById = asyncHandler(
     if (mongoose.isValidObjectId(tacticBoardId)) {
       const findResult = await TacticBoard.findOne({ _id: tacticBoardId });
       if (findResult) {
-        if (!req.UserInfo?.id) {
-          res.status(401).json({ message: "Unauthorized" });
-          return;
-        }
-        const accessUser = await TacticboardAccess.findOne({
-          user: req.UserInfo.id,
-          tacticboard: req.params.id,
-        });
-        const hasAccess =
-          findResult.user?.toString() === req.UserInfo.id ||
-          req.UserInfo.roles?.includes("Admin") ||
-          req.UserInfo.roles?.includes("admin") ||
-          (accessUser && accessUser.access == "edit");
-
-        if (!hasAccess) {
-          res.status(403).json({ message: "Forbidden" });
+        if (
+          !(await requireResourceAuthorization(
+            req,
+            res,
+            {
+              type: "tacticBoard",
+              id: tacticBoardId,
+              ownerId: findResult.user?.toString(),
+              isPrivate: findResult.isPrivate ?? false,
+            },
+            "edit",
+          ))
+        ) {
           return;
         }
 
@@ -472,23 +459,19 @@ export const deleteById = asyncHandler(
       const findResult = await TacticBoard.findOne({ _id: req.params.id });
 
       if (findResult) {
-        // Check permissions
-        if (!req.UserInfo?.id) {
-          res.status(401).json({ message: "Unauthorized" });
-          return;
-        }
-        const accessUser = await TacticboardAccess.findOne({
-          user: req.UserInfo.id,
-          tacticboard: req.params.id,
-        });
-        const hasAccess =
-          findResult.user?.toString() === req.UserInfo.id ||
-          req.UserInfo.roles?.includes("Admin") ||
-          req.UserInfo.roles?.includes("admin") ||
-          (accessUser && accessUser.access == "edit");
-
-        if (!hasAccess) {
-          res.status(403).json({ message: "Forbidden" });
+        if (
+          !(await requireResourceAuthorization(
+            req,
+            res,
+            {
+              type: "tacticBoard",
+              id: req.params.id,
+              ownerId: findResult.user?.toString(),
+              isPrivate: findResult.isPrivate ?? false,
+            },
+            "delete",
+          ))
+        ) {
           return;
         }
 
@@ -541,23 +524,19 @@ export const createNewPage = asyncHandler(
     if (mongoose.isValidObjectId(tacticBoardId)) {
       const findResult = await TacticBoard.findOne({ _id: tacticBoardId });
       if (findResult) {
-        // Authorization check
-        if (!req.UserInfo?.id) {
-          res.status(401).json({ message: "Unauthorized" });
-          return;
-        }
-        const accessUser = await TacticboardAccess.findOne({
-          user: req.UserInfo.id,
-          tacticboard: req.params.id,
-        });
-        const hasAccess =
-          findResult.user?.toString() === req.UserInfo.id ||
-          req.UserInfo.roles?.includes("Admin") ||
-          req.UserInfo.roles?.includes("admin") ||
-          (accessUser && accessUser.access == "edit");
-
-        if (!hasAccess) {
-          res.status(403).json({ message: "Forbidden" });
+        if (
+          !(await requireResourceAuthorization(
+            req,
+            res,
+            {
+              type: "tacticBoard",
+              id: tacticBoardId,
+              ownerId: findResult.user?.toString(),
+              isPrivate: findResult.isPrivate ?? false,
+            },
+            "edit",
+          ))
+        ) {
           return;
         }
 
@@ -592,23 +571,19 @@ export const insertPageAtPosition = asyncHandler(
     if (mongoose.isValidObjectId(tacticBoardId) && !isNaN(insertPosition)) {
       const findResult = await TacticBoard.findOne({ _id: tacticBoardId });
       if (findResult) {
-        // Authorization check
-        if (!req.UserInfo?.id) {
-          res.status(401).json({ message: "Unauthorized" });
-          return;
-        }
-        const accessUser = await TacticboardAccess.findOne({
-          user: req.UserInfo.id,
-          tacticboard: req.params.id,
-        });
-        const hasAccess =
-          findResult.user?.toString() === req.UserInfo.id ||
-          req.UserInfo.roles?.includes("Admin") ||
-          req.UserInfo.roles?.includes("admin") ||
-          (accessUser && accessUser.access == "edit");
-
-        if (!hasAccess) {
-          res.status(403).json({ message: "Forbidden" });
+        if (
+          !(await requireResourceAuthorization(
+            req,
+            res,
+            {
+              type: "tacticBoard",
+              id: tacticBoardId,
+              ownerId: findResult.user?.toString(),
+              isPrivate: findResult.isPrivate ?? false,
+            },
+            "edit",
+          ))
+        ) {
           return;
         }
 
@@ -661,23 +636,19 @@ export const deletePageById = asyncHandler(
     ) {
       const findResult = await TacticBoard.findOne({ _id: tacticBoardId });
       if (findResult) {
-        // Authorization check
-        if (!req.UserInfo?.id) {
-          res.status(401).json({ message: "Unauthorized" });
-          return;
-        }
-        const accessUser = await TacticboardAccess.findOne({
-          user: req.UserInfo.id,
-          tacticboard: req.params.id,
-        });
-        const hasAccess =
-          findResult.user?.toString() === req.UserInfo.id ||
-          req.UserInfo.roles?.includes("Admin") ||
-          req.UserInfo.roles?.includes("admin") ||
-          (accessUser && accessUser.access == "edit");
-
-        if (!hasAccess) {
-          res.status(403).json({ message: "Forbidden" });
+        if (
+          !(await requireResourceAuthorization(
+            req,
+            res,
+            {
+              type: "tacticBoard",
+              id: tacticBoardId,
+              ownerId: findResult.user?.toString(),
+              isPrivate: findResult.isPrivate ?? false,
+            },
+            "edit",
+          ))
+        ) {
           return;
         }
 
@@ -721,31 +692,26 @@ export const checkAccess = asyncHandler(
       return;
     }
 
-    // Check if user is the owner
-    if (tacticboard.user?.toString() === req.UserInfo.id) {
-      res.json({ hasAccess: true, type: "owner", level: "edit" });
-      return;
-    }
-
-    // Check if user is an admin
-    if (
-      req.UserInfo.roles?.includes("Admin") ||
-      req.UserInfo.roles?.includes("admin")
-    ) {
-      res.json({ hasAccess: true, type: "admin", level: "edit" });
-      return;
-    }
-
-    // Check if user has been granted access
-    const access = await TacticboardAccess.findOne({
-      user: req.UserInfo.id,
-      tacticboard: req.params.id,
-    });
-
+    const decision = await getResourceAuthorization(
+      req,
+      {
+        type: "tacticBoard",
+        id: req.params.id,
+        ownerId: tacticboard.user?.toString(),
+        isPrivate: tacticboard.isPrivate ?? false,
+      },
+      "view",
+    );
     res.json({
-      hasAccess: !!access,
-      type: access ? "granted" : null,
-      level: access?.access || null,
+      hasAccess: decision.allowed,
+      type: decision.allowed ? decision.basis : null,
+      level:
+        decision.allowed && decision.basis === "granted"
+          ? decision.accessLevel
+          : decision.allowed &&
+              (decision.basis === "owner" || decision.basis === "admin")
+            ? "edit"
+            : null,
     });
   },
 );
@@ -766,21 +732,19 @@ export const setAccess = asyncHandler(
       return;
     }
 
-    // Check if user is the creator/owner or admin (only they can grant access)
-    if (!req.UserInfo?.id) {
-      res.status(401).json({ message: "Unauthorized" });
-      return;
-    }
-
-    const isCreator =
-      tacticboard.user?.toString() === req.UserInfo.id ||
-      req.UserInfo.roles?.includes("Admin") ||
-      req.UserInfo.roles?.includes("admin");
-
-    if (!isCreator) {
-      res
-        .status(403)
-        .json({ message: "Only the creator can modify access settings" });
+    if (
+      !(await requireResourceAuthorization(
+        req,
+        res,
+        {
+          type: "tacticBoard",
+          id: req.params.id,
+          ownerId: tacticboard.user?.toString(),
+          isPrivate: tacticboard.isPrivate ?? false,
+        },
+        "manageAccess",
+      ))
+    ) {
       return;
     }
 
@@ -832,21 +796,19 @@ export const deleteAccess = asyncHandler(
       return;
     }
 
-    // Check if user is the creator/owner or admin (only they can remove access)
-    if (!req.UserInfo?.id) {
-      res.status(401).json({ message: "Unauthorized" });
-      return;
-    }
-
-    const isCreator =
-      tacticboard.user?.toString() === req.UserInfo.id ||
-      req.UserInfo.roles?.includes("Admin") ||
-      req.UserInfo.roles?.includes("admin");
-
-    if (!isCreator) {
-      res
-        .status(403)
-        .json({ message: "Only the creator can modify access settings" });
+    if (
+      !(await requireResourceAuthorization(
+        req,
+        res,
+        {
+          type: "tacticBoard",
+          id: req.params.id,
+          ownerId: tacticboard.user?.toString(),
+          isPrivate: tacticboard.isPrivate ?? false,
+        },
+        "manageAccess",
+      ))
+    ) {
       return;
     }
 
@@ -891,20 +853,19 @@ export const duplicateById = asyncHandler(
       return;
     }
 
-    const isOwner = tacticboard.user?.toString() === req.UserInfo.id;
-    const isAdmin =
-      req.UserInfo.roles?.includes("Admin") ||
-      req.UserInfo.roles?.includes("admin");
-    const hasSharedAccess = await TacticboardAccess.exists({
-      user: req.UserInfo.id,
-      tacticboard: req.params.id,
-    });
-
-    const canDuplicate =
-      !tacticboard.isPrivate || isOwner || isAdmin || Boolean(hasSharedAccess);
-
-    if (!canDuplicate) {
-      res.status(403).json({ message: "Forbidden" });
+    if (
+      !(await requireResourceAuthorization(
+        req,
+        res,
+        {
+          type: "tacticBoard",
+          id: req.params.id,
+          ownerId: tacticboard.user?.toString(),
+          isPrivate: tacticboard.isPrivate ?? false,
+        },
+        "view",
+      ))
+    ) {
       return;
     }
 
@@ -966,23 +927,19 @@ export const getAllAccessUsers = asyncHandler(
       return;
     }
 
-    // Check if user has access to view access list
-    if (!req.UserInfo?.id) {
-      res.status(401).json({ message: "Unauthorized" });
-      return;
-    }
-
-    const hasAccess =
-      tacticboard.user?.toString() === req.UserInfo.id ||
-      req.UserInfo.roles?.includes("Admin") ||
-      req.UserInfo.roles?.includes("admin") ||
-      (await TacticboardAccess.exists({
-        user: req.UserInfo.id,
-        tacticboard: req.params.id,
-      }));
-
-    if (!hasAccess) {
-      res.status(403).json({ message: "Forbidden" });
+    if (
+      !(await requireResourceAuthorization(
+        req,
+        res,
+        {
+          type: "tacticBoard",
+          id: req.params.id,
+          ownerId: tacticboard.user?.toString(),
+          isPrivate: tacticboard.isPrivate ?? false,
+        },
+        "manageAccess",
+      ))
+    ) {
       return;
     }
 
@@ -1021,13 +978,19 @@ export const shareTacticBoard = asyncHandler(
       return;
     }
 
-    const isOwner = tacticBoard.user?.toString() === req.UserInfo.id;
-    const isAdmin = req.UserInfo.roles?.some(
-      (role) => role.toLowerCase() === "admin",
-    );
-
-    if (!isOwner && !isAdmin) {
-      res.status(403).json({ message: "Forbidden" });
+    if (
+      !(await requireResourceAuthorization(
+        req,
+        res,
+        {
+          type: "tacticBoard",
+          id: req.params.id,
+          ownerId: tacticBoard.user?.toString(),
+          isPrivate: tacticBoard.isPrivate ?? false,
+        },
+        "manageAccess",
+      ))
+    ) {
       return;
     }
 
@@ -1105,19 +1068,19 @@ export const createShareLink = asyncHandler(
       return;
     }
 
-    const accessUser = await TacticboardAccess.findOne({
-      user: req.UserInfo.id,
-      tacticboard: req.params.id,
-    });
-
-    const hasEditAccess =
-      tacticboard.user?.toString() === req.UserInfo.id ||
-      req.UserInfo.roles?.includes("Admin") ||
-      req.UserInfo.roles?.includes("admin") ||
-      (accessUser && accessUser.access === "edit");
-
-    if (!hasEditAccess) {
-      res.status(403).json({ message: "Forbidden" });
+    if (
+      !(await requireResourceAuthorization(
+        req,
+        res,
+        {
+          type: "tacticBoard",
+          id: req.params.id,
+          ownerId: tacticboard.user?.toString(),
+          isPrivate: tacticboard.isPrivate ?? false,
+        },
+        "edit",
+      ))
+    ) {
       return;
     }
     try {
@@ -1162,19 +1125,19 @@ export const deleteShareLink = asyncHandler(
       return;
     }
 
-    const accessUser = await TacticboardAccess.findOne({
-      user: req.UserInfo.id,
-      tacticboard: req.params.id,
-    });
-
-    const hasEditAccess =
-      tacticboard.user?.toString() === req.UserInfo.id ||
-      req.UserInfo.roles?.includes("Admin") ||
-      req.UserInfo.roles?.includes("admin") ||
-      (accessUser && accessUser.access === "edit");
-
-    if (!hasEditAccess) {
-      res.status(403).json({ message: "Forbidden" });
+    if (
+      !(await requireResourceAuthorization(
+        req,
+        res,
+        {
+          type: "tacticBoard",
+          id: req.params.id,
+          ownerId: tacticboard.user?.toString(),
+          isPrivate: tacticboard.isPrivate ?? false,
+        },
+        "edit",
+      ))
+    ) {
       return;
     }
 

--- a/server/controllers/tacticboardController.ts
+++ b/server/controllers/tacticboardController.ts
@@ -11,7 +11,9 @@ import { logEvents } from "../middleware/logger";
 import {
   getResourceAuthorization,
   requireResourceAuthorization,
+  serializeResourceAuthorizationDecision,
 } from "./helpers/requireResourceAuthorization";
+import { authorizationResourceFor } from "../authorization/resourceAuthorization";
 
 interface UserInfo {
   id?: string;
@@ -231,12 +233,7 @@ export const getById = asyncHandler(
           !(await requireResourceAuthorization(
             req,
             res,
-            {
-              type: "tacticBoard",
-              id: req.params.id,
-              ownerId: result.user?.toString(),
-              isPrivate: result.isPrivate ?? false,
-            },
+            authorizationResourceFor.tacticBoard(req.params.id, result),
             "view",
           ))
         ) {
@@ -288,21 +285,20 @@ export const updateById = asyncHandler(
           !(await requireResourceAuthorization(
             req,
             res,
-            {
-              type: "tacticBoard",
-              id: req.params.id,
-              ownerId: findResult.user?.toString(),
-              isPrivate: findResult.isPrivate ?? false,
-            },
+            authorizationResourceFor.tacticBoard(req.params.id, findResult),
             "edit",
           ))
         ) {
           return;
         }
 
+        const updates = { ...(req.body as Record<string, unknown>) };
+        delete updates.user;
+        delete updates.owner;
+
         const result = await TacticBoard.updateOne(
           { _id: req.params.id },
-          { $set: req.body },
+          { $set: updates },
         );
         if (result.modifiedCount > 0) {
           res.json({ message: "Tacticboard updated successfully" });
@@ -334,12 +330,7 @@ export const updatePageById = asyncHandler(
           !(await requireResourceAuthorization(
             req,
             res,
-            {
-              type: "tacticBoard",
-              id: tacticBoardId,
-              ownerId: findResult.user?.toString(),
-              isPrivate: findResult.isPrivate ?? false,
-            },
+            authorizationResourceFor.tacticBoard(tacticBoardId, findResult),
             "edit",
           ))
         ) {
@@ -386,12 +377,7 @@ export const updateMetaById = asyncHandler(
           !(await requireResourceAuthorization(
             req,
             res,
-            {
-              type: "tacticBoard",
-              id: tacticBoardId,
-              ownerId: findResult.user?.toString(),
-              isPrivate: findResult.isPrivate ?? false,
-            },
+            authorizationResourceFor.tacticBoard(tacticBoardId, findResult),
             "edit",
           ))
         ) {
@@ -463,12 +449,7 @@ export const deleteById = asyncHandler(
           !(await requireResourceAuthorization(
             req,
             res,
-            {
-              type: "tacticBoard",
-              id: req.params.id,
-              ownerId: findResult.user?.toString(),
-              isPrivate: findResult.isPrivate ?? false,
-            },
+            authorizationResourceFor.tacticBoard(req.params.id, findResult),
             "delete",
           ))
         ) {
@@ -528,12 +509,7 @@ export const createNewPage = asyncHandler(
           !(await requireResourceAuthorization(
             req,
             res,
-            {
-              type: "tacticBoard",
-              id: tacticBoardId,
-              ownerId: findResult.user?.toString(),
-              isPrivate: findResult.isPrivate ?? false,
-            },
+            authorizationResourceFor.tacticBoard(tacticBoardId, findResult),
             "edit",
           ))
         ) {
@@ -575,12 +551,7 @@ export const insertPageAtPosition = asyncHandler(
           !(await requireResourceAuthorization(
             req,
             res,
-            {
-              type: "tacticBoard",
-              id: tacticBoardId,
-              ownerId: findResult.user?.toString(),
-              isPrivate: findResult.isPrivate ?? false,
-            },
+            authorizationResourceFor.tacticBoard(tacticBoardId, findResult),
             "edit",
           ))
         ) {
@@ -640,12 +611,7 @@ export const deletePageById = asyncHandler(
           !(await requireResourceAuthorization(
             req,
             res,
-            {
-              type: "tacticBoard",
-              id: tacticBoardId,
-              ownerId: findResult.user?.toString(),
-              isPrivate: findResult.isPrivate ?? false,
-            },
+            authorizationResourceFor.tacticBoard(tacticBoardId, findResult),
             "edit",
           ))
         ) {
@@ -694,25 +660,10 @@ export const checkAccess = asyncHandler(
 
     const decision = await getResourceAuthorization(
       req,
-      {
-        type: "tacticBoard",
-        id: req.params.id,
-        ownerId: tacticboard.user?.toString(),
-        isPrivate: tacticboard.isPrivate ?? false,
-      },
+      authorizationResourceFor.tacticBoard(req.params.id, tacticboard),
       "view",
     );
-    res.json({
-      hasAccess: decision.allowed,
-      type: decision.allowed ? decision.basis : null,
-      level:
-        decision.allowed && decision.basis === "granted"
-          ? decision.accessLevel
-          : decision.allowed &&
-              (decision.basis === "owner" || decision.basis === "admin")
-            ? "edit"
-            : null,
-    });
+    res.json(serializeResourceAuthorizationDecision(decision));
   },
 );
 
@@ -736,12 +687,7 @@ export const setAccess = asyncHandler(
       !(await requireResourceAuthorization(
         req,
         res,
-        {
-          type: "tacticBoard",
-          id: req.params.id,
-          ownerId: tacticboard.user?.toString(),
-          isPrivate: tacticboard.isPrivate ?? false,
-        },
+        authorizationResourceFor.tacticBoard(req.params.id, tacticboard),
         "manageAccess",
       ))
     ) {
@@ -800,12 +746,7 @@ export const deleteAccess = asyncHandler(
       !(await requireResourceAuthorization(
         req,
         res,
-        {
-          type: "tacticBoard",
-          id: req.params.id,
-          ownerId: tacticboard.user?.toString(),
-          isPrivate: tacticboard.isPrivate ?? false,
-        },
+        authorizationResourceFor.tacticBoard(req.params.id, tacticboard),
         "manageAccess",
       ))
     ) {
@@ -857,12 +798,7 @@ export const duplicateById = asyncHandler(
       !(await requireResourceAuthorization(
         req,
         res,
-        {
-          type: "tacticBoard",
-          id: req.params.id,
-          ownerId: tacticboard.user?.toString(),
-          isPrivate: tacticboard.isPrivate ?? false,
-        },
+        authorizationResourceFor.tacticBoard(req.params.id, tacticboard),
         "view",
       ))
     ) {
@@ -931,12 +867,7 @@ export const getAllAccessUsers = asyncHandler(
       !(await requireResourceAuthorization(
         req,
         res,
-        {
-          type: "tacticBoard",
-          id: req.params.id,
-          ownerId: tacticboard.user?.toString(),
-          isPrivate: tacticboard.isPrivate ?? false,
-        },
+        authorizationResourceFor.tacticBoard(req.params.id, tacticboard),
         "manageAccess",
       ))
     ) {
@@ -982,12 +913,7 @@ export const shareTacticBoard = asyncHandler(
       !(await requireResourceAuthorization(
         req,
         res,
-        {
-          type: "tacticBoard",
-          id: req.params.id,
-          ownerId: tacticBoard.user?.toString(),
-          isPrivate: tacticBoard.isPrivate ?? false,
-        },
+        authorizationResourceFor.tacticBoard(req.params.id, tacticBoard),
         "manageAccess",
       ))
     ) {
@@ -1072,12 +998,7 @@ export const createShareLink = asyncHandler(
       !(await requireResourceAuthorization(
         req,
         res,
-        {
-          type: "tacticBoard",
-          id: req.params.id,
-          ownerId: tacticboard.user?.toString(),
-          isPrivate: tacticboard.isPrivate ?? false,
-        },
+        authorizationResourceFor.tacticBoard(req.params.id, tacticboard),
         "edit",
       ))
     ) {
@@ -1129,12 +1050,7 @@ export const deleteShareLink = asyncHandler(
       !(await requireResourceAuthorization(
         req,
         res,
-        {
-          type: "tacticBoard",
-          id: req.params.id,
-          ownerId: tacticboard.user?.toString(),
-          isPrivate: tacticboard.isPrivate ?? false,
-        },
+        authorizationResourceFor.tacticBoard(req.params.id, tacticboard),
         "edit",
       ))
     ) {

--- a/server/routes/practicePlanRoutes.ts
+++ b/server/routes/practicePlanRoutes.ts
@@ -13,6 +13,7 @@ import {
   createShareLink,
   deleteShareLink,
   getByShareToken,
+  checkAccess,
 } from "../controllers/practicePlanController";
 import verifyJWT from "../middleware/verifyJWT";
 import verifyJWTOptional from "../middleware/verifyJWTOptional";
@@ -37,6 +38,7 @@ router.delete("/:id", verifyJWT, deletePracticePlan);
 router.post("/:id/access", verifyJWT, setAccess);
 router.get("/:id/access", verifyJWT, getAllAccessUsers);
 router.delete("/:id/access", verifyJWT, deleteAccess);
+router.get("/:id/checkAccess", verifyJWT, checkAccess);
 router.route("/:id/share").post(verifyJWT, sharePracticePlan);
 router
   .route("/:id/share-link")

--- a/server/tests/contract/resourceAuthorization.contract.spec.ts
+++ b/server/tests/contract/resourceAuthorization.contract.spec.ts
@@ -1,0 +1,182 @@
+import request from "supertest";
+import Exercise from "../../models/exercise";
+import ExerciseAccess from "../../models/exerciseAccess";
+import TacticBoard from "../../models/tacticboard";
+import TacticboardAccess from "../../models/tacticboardAccess";
+import { PracticePlan } from "../../models/practicePlan";
+import PracticePlanAccess from "../../models/practicePlanAccess";
+import { app } from "../setup";
+import { createVerifiedUser, getAccessToken } from "../utils/auth";
+
+jest.setTimeout(30_000);
+
+const authorizationFor = async (user: { id: string }) =>
+  `Bearer ${await getAccessToken(user)}`;
+
+describe("resource authorization HTTP mapping", () => {
+  it("maps missing and insufficient authority to 401 and 403", async () => {
+    const { user: owner } = await createVerifiedUser({
+      email: "private_owner@example.com",
+    });
+    const { user: unrelated } = await createVerifiedUser({
+      email: "private_unrelated@example.com",
+    });
+    const tacticBoard = await TacticBoard.create({
+      name: "Private Board",
+      user: owner._id,
+      isPrivate: true,
+      pages: [],
+    });
+
+    const anonymousResponse = await request(app).get(
+      `/api/tacticboards/${tacticBoard._id}`,
+    );
+    const unrelatedResponse = await request(app)
+      .get(`/api/tacticboards/${tacticBoard._id}`)
+      .set("Authorization", await authorizationFor(unrelated));
+
+    expect(anonymousResponse.status).toBe(401);
+    expect(unrelatedResponse.status).toBe(403);
+  });
+
+  it("prevents an Exercise editor from deleting or managing Access", async () => {
+    const { user: owner } = await createVerifiedUser({
+      email: "exercise_owner@example.com",
+    });
+    const { user: editor } = await createVerifiedUser({
+      email: "exercise_editor@example.com",
+    });
+    const { user: target } = await createVerifiedUser({
+      email: "exercise_target@example.com",
+    });
+    const exercise = await Exercise.create({
+      name: "Authorization Exercise",
+      persons: 6,
+      time_min: 10,
+      user: owner._id,
+    });
+    await ExerciseAccess.create({
+      user: editor._id,
+      exercise: exercise._id,
+      access: "edit",
+    });
+    const editorAuthorization = await authorizationFor(editor);
+
+    const deleteResponse = await request(app)
+      .delete(`/api/exercises/${exercise._id}`)
+      .set("Authorization", editorAuthorization);
+    const accessResponse = await request(app)
+      .post(`/api/exercises/${exercise._id}/access`)
+      .set("Authorization", editorAuthorization)
+      .send({ userId: target._id, access: "edit" });
+
+    expect(deleteResponse.status).toBe(403);
+    expect(accessResponse.status).toBe(403);
+  });
+
+  it("prevents a TacticBoard editor from deleting or managing Access", async () => {
+    const { user: owner } = await createVerifiedUser({
+      email: "board_owner@example.com",
+    });
+    const { user: editor } = await createVerifiedUser({
+      email: "board_editor@example.com",
+    });
+    const { user: target } = await createVerifiedUser({
+      email: "board_target@example.com",
+    });
+    const tacticBoard = await TacticBoard.create({
+      name: "Authorization Board",
+      user: owner._id,
+      isPrivate: true,
+      pages: [],
+    });
+    await TacticboardAccess.create({
+      user: editor._id,
+      tacticboard: tacticBoard._id,
+      access: "edit",
+    });
+    const editorAuthorization = await authorizationFor(editor);
+
+    const deleteResponse = await request(app)
+      .delete(`/api/tacticboards/${tacticBoard._id}`)
+      .set("Authorization", editorAuthorization);
+    const accessResponse = await request(app)
+      .post(`/api/tacticboards/${tacticBoard._id}/access`)
+      .set("Authorization", editorAuthorization)
+      .send({ userId: target._id, access: "view" });
+
+    expect(deleteResponse.status).toBe(403);
+    expect(accessResponse.status).toBe(403);
+  });
+
+  it("allows a TacticBoard editor to manage its Share Link", async () => {
+    const { user: owner } = await createVerifiedUser({
+      email: "share_owner@example.com",
+    });
+    const { user: editor } = await createVerifiedUser({
+      email: "share_editor@example.com",
+    });
+    const tacticBoard = await TacticBoard.create({
+      name: "Shareable Board",
+      user: owner._id,
+      isPrivate: true,
+      pages: [],
+    });
+    await TacticboardAccess.create({
+      user: editor._id,
+      tacticboard: tacticBoard._id,
+      access: "edit",
+    });
+    const editorAuthorization = await authorizationFor(editor);
+
+    const createResponse = await request(app)
+      .post(`/api/tacticboards/${tacticBoard._id}/share-link`)
+      .set("Authorization", editorAuthorization);
+    const deleteResponse = await request(app)
+      .delete(`/api/tacticboards/${tacticBoard._id}/share-link`)
+      .set("Authorization", editorAuthorization);
+
+    expect(createResponse.status).toBe(201);
+    expect(deleteResponse.status).toBe(200);
+  });
+
+  it("allows a PracticePlan editor to edit but not delete or manage Access", async () => {
+    const { user: owner } = await createVerifiedUser({
+      email: "plan_contract_owner@example.com",
+    });
+    const { user: editor } = await createVerifiedUser({
+      email: "plan_contract_editor@example.com",
+    });
+    const { user: target } = await createVerifiedUser({
+      email: "plan_contract_target@example.com",
+    });
+    const practicePlan = await PracticePlan.create({
+      name: "Authorization Plan",
+      user: owner._id,
+      isPrivate: true,
+      sections: [],
+    });
+    await PracticePlanAccess.create({
+      user: editor._id,
+      practicePlan: practicePlan._id,
+      access: "edit",
+    });
+    const editorAuthorization = await authorizationFor(editor);
+
+    const editResponse = await request(app)
+      .patch(`/api/practice-plans/${practicePlan._id}`)
+      .set("Authorization", editorAuthorization)
+      .send({ description: "Edited" });
+    const deleteResponse = await request(app)
+      .delete(`/api/practice-plans/${practicePlan._id}`)
+      .set("Authorization", editorAuthorization);
+    const accessResponse = await request(app)
+      .post(`/api/practice-plans/${practicePlan._id}/access`)
+      .set("Authorization", editorAuthorization)
+      .send({ userId: target._id, access: "view" });
+
+    expect(editResponse.status).toBe(200);
+    expect(deleteResponse.status).toBe(403);
+    expect(accessResponse.status).toBe(403);
+  });
+});

--- a/server/tests/contract/resourceAuthorization.contract.spec.ts
+++ b/server/tests/contract/resourceAuthorization.contract.spec.ts
@@ -179,4 +179,132 @@ describe("resource authorization HTTP mapping", () => {
     expect(deleteResponse.status).toBe(403);
     expect(accessResponse.status).toBe(403);
   });
+
+  it("reports editor capability without exposing named Access", async () => {
+    const { user: owner } = await createVerifiedUser({
+      email: "capability_owner@example.com",
+    });
+    const { user: editor } = await createVerifiedUser({
+      email: "capability_editor@example.com",
+    });
+    const exercise = await Exercise.create({
+      name: "Capability Exercise",
+      persons: 6,
+      time_min: 10,
+      user: owner._id,
+    });
+    const tacticBoard = await TacticBoard.create({
+      name: "Capability Board",
+      user: owner._id,
+      isPrivate: true,
+      pages: [],
+    });
+    const practicePlan = await PracticePlan.create({
+      name: "Capability Plan",
+      user: owner._id,
+      isPrivate: true,
+      sections: [],
+    });
+    await Promise.all([
+      ExerciseAccess.create({
+        user: editor._id,
+        exercise: exercise._id,
+        access: "edit",
+      }),
+      TacticboardAccess.create({
+        user: editor._id,
+        tacticboard: tacticBoard._id,
+        access: "edit",
+      }),
+      PracticePlanAccess.create({
+        user: editor._id,
+        practicePlan: practicePlan._id,
+        access: "edit",
+      }),
+    ]);
+    const editorAuthorization = await authorizationFor(editor);
+    const resources = [
+      ["exercises", exercise._id],
+      ["tacticboards", tacticBoard._id],
+      ["practice-plans", practicePlan._id],
+    ] as const;
+
+    for (const [path, id] of resources) {
+      const capabilityResponse = await request(app)
+        .get(`/api/${path}/${id}/checkAccess`)
+        .set("Authorization", editorAuthorization);
+      const accessListResponse = await request(app)
+        .get(`/api/${path}/${id}/access`)
+        .set("Authorization", editorAuthorization);
+
+      expect(capabilityResponse.status).toBe(200);
+      expect(capabilityResponse.body).toEqual({
+        hasAccess: true,
+        type: "granted",
+        level: "edit",
+      });
+      expect(accessListResponse.status).toBe(403);
+    }
+  });
+
+  it("does not let editors transfer resource ownership", async () => {
+    const { user: owner } = await createVerifiedUser({
+      email: "immutable_owner@example.com",
+    });
+    const { user: editor } = await createVerifiedUser({
+      email: "immutable_editor@example.com",
+    });
+    const exercise = await Exercise.create({
+      name: "Immutable Exercise",
+      persons: 6,
+      time_min: 10,
+      user: owner._id,
+    });
+    const tacticBoard = await TacticBoard.create({
+      name: "Immutable Board",
+      user: owner._id,
+      isPrivate: true,
+      pages: [],
+    });
+    await Promise.all([
+      ExerciseAccess.create({
+        user: editor._id,
+        exercise: exercise._id,
+        access: "edit",
+      }),
+      TacticboardAccess.create({
+        user: editor._id,
+        tacticboard: tacticBoard._id,
+        access: "edit",
+      }),
+    ]);
+    const editorAuthorization = await authorizationFor(editor);
+    const resources = [
+      {
+        path: "exercises",
+        id: exercise._id,
+        load: () => Exercise.findById(exercise._id),
+      },
+      {
+        path: "tacticboards",
+        id: tacticBoard._id,
+        load: () => TacticBoard.findById(tacticBoard._id),
+      },
+    ] as const;
+
+    for (const { path, id, load } of resources) {
+      const updateResponse = await request(app)
+        .put(`/api/${path}/${id}`)
+        .set("Authorization", editorAuthorization)
+        .send({ user: editor._id });
+      const persistedResource = await load();
+      const deleteResponse = await request(app)
+        .delete(`/api/${path}/${id}`)
+        .set("Authorization", editorAuthorization);
+
+      expect(updateResponse.status).toBe(200);
+      expect(persistedResource?.user?.toString()).toBe(owner._id.toString());
+      expect(deleteResponse.status).toBe(403);
+    }
+  });
 });

--- a/server/tests/unit/resourceAuthorization.spec.ts
+++ b/server/tests/unit/resourceAuthorization.spec.ts
@@ -1,0 +1,295 @@
+import {
+  AccessGrantAdapter,
+  createResourceAuthorization,
+  ResourceAuthorizationRequest,
+  ResourceType,
+} from "../../authorization/resourceAuthorization";
+
+jest.setTimeout(30_000);
+
+const noGrant: AccessGrantAdapter = {
+  findAccessLevel: jest.fn().mockResolvedValue(null),
+};
+
+const withAdapter = (adapter: AccessGrantAdapter) =>
+  createResourceAuthorization(
+    Object.fromEntries(
+      (["exercise", "tacticBoard", "practicePlan"] as ResourceType[]).map(
+        (type) => [type, adapter],
+      ),
+    ) as Record<ResourceType, AccessGrantAdapter>,
+  );
+
+const decideResourceAuthorization = withAdapter(noGrant);
+
+const request = (
+  overrides: Partial<ResourceAuthorizationRequest> = {},
+): ResourceAuthorizationRequest => ({
+  action: "view",
+  actor: undefined,
+  resource: {
+    type: "tacticBoard",
+    id: "resource-id",
+    ownerId: "owner-id",
+    isPrivate: false,
+  },
+  ...overrides,
+});
+
+describe("decideResourceAuthorization", () => {
+  it("allows an anonymous visitor to view a Public resource", async () => {
+    await expect(
+      decideResourceAuthorization(request()),
+    ).resolves.toEqual({ allowed: true, basis: "public" });
+  });
+
+  const actorCases: Record<
+    "anonymous" | "unrelated" | "owner" | "admin",
+    ResourceAuthorizationRequest["actor"]
+  > = {
+    anonymous: undefined,
+    unrelated: { id: "other-id", roles: ["user"] },
+    owner: { id: "owner-id", roles: ["user"] },
+    admin: { id: "admin-id", roles: ["AdMiN"] },
+  };
+
+  const exhaustiveActors = [
+    {
+      name: "anonymous",
+      actor: undefined,
+      grant: null,
+      publicActions: ["view"],
+      privateActions: [],
+    },
+    {
+      name: "unrelated",
+      actor: { id: "unrelated-id", roles: ["user"] },
+      grant: null,
+      publicActions: ["view"],
+      privateActions: [],
+    },
+    {
+      name: "view Access",
+      actor: { id: "viewer-id", roles: ["user"] },
+      grant: "view",
+      publicActions: ["view"],
+      privateActions: ["view"],
+    },
+    {
+      name: "edit Access",
+      actor: { id: "editor-id", roles: ["user"] },
+      grant: "edit",
+      publicActions: ["view", "edit"],
+      privateActions: ["view", "edit"],
+    },
+    {
+      name: "Owner",
+      actor: { id: "owner-id", roles: ["user"] },
+      grant: null,
+      publicActions: ["view", "edit", "delete", "manageAccess"],
+      privateActions: ["view", "edit", "delete", "manageAccess"],
+    },
+    {
+      name: "Admin",
+      actor: { id: "admin-id", roles: ["admin"] },
+      grant: null,
+      publicActions: ["view", "edit", "delete", "manageAccess"],
+      privateActions: ["view", "edit", "delete", "manageAccess"],
+    },
+  ] satisfies Array<{
+    name: string;
+    actor: ResourceAuthorizationRequest["actor"];
+    grant: "view" | "edit" | null;
+    publicActions: string[];
+    privateActions: string[];
+  }>;
+
+  const exhaustiveCases = (
+    ["exercise", "tacticBoard", "practicePlan"] as ResourceType[]
+  ).flatMap((type) =>
+    [false, true].flatMap((isPrivate) =>
+      exhaustiveActors.flatMap((actorCase) =>
+        (["view", "edit", "delete", "manageAccess"] as const).map(
+          (action) => {
+            const effectiveVisibility =
+              type === "exercise" || !isPrivate ? "public" : "private";
+            const allowedActions =
+              effectiveVisibility === "public"
+                ? actorCase.publicActions
+                : actorCase.privateActions;
+            return {
+              type,
+              isPrivate,
+              actorCase,
+              action,
+              allowed: allowedActions.includes(action),
+            };
+          },
+        ),
+      ),
+    ),
+  );
+
+  it.each(exhaustiveCases)(
+    "$type isPrivate=$isPrivate: $actorCase.name requesting $action returns allowed=$allowed",
+    async ({ type, isPrivate, actorCase, action, allowed }) => {
+      const adapter: AccessGrantAdapter = {
+        findAccessLevel: jest.fn().mockResolvedValue(actorCase.grant),
+      };
+
+      const decision = await withAdapter(adapter)(
+        request({
+          action,
+          actor: actorCase.actor,
+          resource: {
+            type,
+            id: "resource-id",
+            ownerId: "owner-id",
+            isPrivate,
+          },
+        }),
+      );
+
+      expect(decision.allowed).toBe(allowed);
+    },
+  );
+
+  it.each([
+    ["anonymous", "view", false, true, "public"],
+    ["anonymous", "view", true, false, "authenticationRequired"],
+    ["anonymous", "edit", false, false, "authenticationRequired"],
+    ["unrelated", "view", false, true, "public"],
+    ["unrelated", "view", true, false, "forbidden"],
+    ["unrelated", "edit", false, false, "forbidden"],
+    ["unrelated", "delete", false, false, "forbidden"],
+    ["unrelated", "manageAccess", false, false, "forbidden"],
+    ["owner", "view", true, true, "owner"],
+    ["owner", "edit", true, true, "owner"],
+    ["owner", "delete", true, true, "owner"],
+    ["owner", "manageAccess", true, true, "owner"],
+    ["admin", "view", true, true, "admin"],
+    ["admin", "edit", true, true, "admin"],
+    ["admin", "delete", true, true, "admin"],
+    ["admin", "manageAccess", true, true, "admin"],
+  ] as const)(
+    "%s requesting %s on isPrivate=%s returns %s",
+    async (actorName, action, isPrivate, allowed, detail) => {
+      const decision = await decideResourceAuthorization(
+        request({
+          action,
+          actor: actorCases[actorName],
+          resource: {
+            type: "tacticBoard",
+            id: "resource-id",
+            ownerId: "owner-id",
+            isPrivate,
+          },
+        }),
+      );
+
+      expect(decision.allowed).toBe(allowed);
+      if (decision.allowed) {
+        expect(decision.basis).toBe(detail);
+      } else {
+        expect(decision.reason).toBe(detail);
+      }
+    },
+  );
+
+  it.each([
+    ["view", "view", true],
+    ["view", "edit", false],
+    ["view", "delete", false],
+    ["view", "manageAccess", false],
+    ["edit", "view", true],
+    ["edit", "edit", true],
+    ["edit", "delete", false],
+    ["edit", "manageAccess", false],
+  ] as const)(
+    "%s Access requesting %s returns allowed=%s",
+    async (accessLevel, action, allowed) => {
+      const adapter: AccessGrantAdapter = {
+        findAccessLevel: jest.fn().mockResolvedValue(accessLevel),
+      };
+      const decision = await withAdapter(adapter)(
+        request({
+          action,
+          actor: { id: "collaborator-id", roles: ["user"] },
+          resource: {
+            type: "practicePlan",
+            id: "resource-id",
+            ownerId: "owner-id",
+            isPrivate: true,
+          },
+        }),
+      );
+
+      expect(decision.allowed).toBe(allowed);
+      if (allowed) {
+        expect(decision).toEqual({
+          allowed: true,
+          basis: "granted",
+          accessLevel,
+        });
+      } else {
+        expect(decision).toEqual({ allowed: false, reason: "forbidden" });
+      }
+    },
+  );
+
+  it.each(["view", "edit", "delete", "manageAccess"] as const)(
+    "treats Exercise as Public for %s decisions",
+    async (action) => {
+      const decision = await decideResourceAuthorization(
+        request({
+          action,
+          resource: {
+            type: "exercise",
+            id: "resource-id",
+            ownerId: "owner-id",
+            isPrivate: true,
+          },
+        }),
+      );
+
+      expect(decision.allowed).toBe(action === "view");
+    },
+  );
+
+  it("preserves granted precedence over Public visibility", async () => {
+    const adapter: AccessGrantAdapter = {
+      findAccessLevel: jest.fn().mockResolvedValue("edit"),
+    };
+
+    await expect(
+      withAdapter(adapter)(
+        request({ actor: { id: "collaborator-id", roles: ["user"] } }),
+      ),
+    ).resolves.toEqual({
+      allowed: true,
+      basis: "granted",
+      accessLevel: "edit",
+    });
+  });
+
+  it("propagates Access adapter failures", async () => {
+    const failure = new Error("database unavailable");
+    const adapter: AccessGrantAdapter = {
+      findAccessLevel: jest.fn().mockRejectedValue(failure),
+    };
+
+    await expect(
+      withAdapter(adapter)(
+        request({
+          actor: { id: "collaborator-id", roles: ["user"] },
+          resource: {
+            type: "practicePlan",
+            id: "resource-id",
+            ownerId: "owner-id",
+            isPrivate: true,
+          },
+        }),
+      ),
+    ).rejects.toBe(failure);
+  });
+});

--- a/server/tests/unit/resourceAuthorizationAdapters.spec.ts
+++ b/server/tests/unit/resourceAuthorizationAdapters.spec.ts
@@ -1,0 +1,43 @@
+import { Types } from "mongoose";
+import { decideResourceAuthorization } from "../../authorization/resourceAuthorization";
+import ExerciseAccess from "../../models/exerciseAccess";
+import PracticePlanAccess from "../../models/practicePlanAccess";
+import TacticboardAccess from "../../models/tacticboardAccess";
+
+jest.setTimeout(30_000);
+
+describe("resource authorization Access adapters", () => {
+  it.each([
+    ["exercise", ExerciseAccess, "exercise"],
+    ["tacticBoard", TacticboardAccess, "tacticboard"],
+    ["practicePlan", PracticePlanAccess, "practicePlan"],
+  ] as const)(
+    "loads edit Access for %s",
+    async (type, AccessModel, resourceField) => {
+      const userId = new Types.ObjectId();
+      const resourceId = new Types.ObjectId();
+      await AccessModel.create({
+        user: userId,
+        [resourceField]: resourceId,
+        access: "edit",
+      });
+
+      await expect(
+        decideResourceAuthorization({
+          action: "edit",
+          actor: { id: userId.toString(), roles: ["user"] },
+          resource: {
+            type,
+            id: resourceId.toString(),
+            ownerId: new Types.ObjectId().toString(),
+            isPrivate: true,
+          },
+        }),
+      ).resolves.toEqual({
+        allowed: true,
+        basis: "granted",
+        accessLevel: "edit",
+      });
+    },
+  );
+});


### PR DESCRIPTION
## Summary
- add one resource authorization decision module for view, edit, delete, and named Access management
- bind Exercise, TacticBoard, and PracticePlan Access lookups behind resource adapters
- migrate individual-resource controller checks to consistent Owner, Admin, grant, and Public rules
- keep edit authority for visibility and Share Link changes while restricting deletion and Access management to Owner/Admin
- map unauthenticated and forbidden decisions consistently to 401 and 403

## Tests
- npm run build
- authorization suites: 183 tests passed
- full server suite: 26/27 suites passed; the remaining MongoMemoryServer startup timeout passed all 6 tests when rerun alone

## Scope
- collection visibility filtering remains unchanged and out of scope
- Share Link token resolution remains separate from User authorization