### PR TITLE
Restore live exercise tag filtering

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -44,6 +44,7 @@
         "yup": "^1.7.1"
       },
       "devDependencies": {
+        "@testing-library/react": "^16.3.2",
         "@types/chroma-js": "^3.1.2",
         "@types/node": "^22.20.0",
         "@types/react": "^18.3.31",
@@ -55,6 +56,7 @@
         "eslint": "^8.57.1",
         "eslint-plugin-react-hooks": "^4.6.2",
         "eslint-plugin-react-refresh": "^0.4.26",
+        "jsdom": "^29.1.1",
         "prettier": "^3.8.4",
         "typescript": "^6.0.3",
         "vite": "^7.3.5",
@@ -71,25 +73,55 @@
       }
     },
     "node_modules/@asamuzakjp/css-color": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
-      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
-        "@csstools/css-calc": "^2.1.3",
-        "@csstools/css-color-parser": "^3.0.9",
-        "@csstools/css-parser-algorithms": "^3.0.4",
-        "@csstools/css-tokenizer": "^3.0.3",
-        "lru-cache": "^10.4.3"
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
-    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "license": "ISC",
-      "optional": true
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
@@ -230,10 +262,24 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
     "node_modules/@csstools/color-helpers": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
-      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
+      "integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -245,15 +291,15 @@
         }
       ],
       "license": "MIT-0",
-      "optional": true,
       "engines": {
-        "node": ">=18"
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@csstools/css-calc": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
-      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+      "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -265,19 +311,19 @@
         }
       ],
       "license": "MIT",
-      "optional": true,
       "engines": {
-        "node": ">=18"
+        "node": ">=20.19.0"
       },
       "peerDependencies": {
-        "@csstools/css-parser-algorithms": "^3.0.5",
-        "@csstools/css-tokenizer": "^3.0.4"
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
       }
     },
     "node_modules/@csstools/css-color-parser": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
-      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.10.tgz",
+      "integrity": "sha512-UZhQLIUyJaaMepqehrCODwCg2KW25vFvLWBmqYFaPclYvvxzj/sG8LBOhBFCp11i9uE7t1EyS+RAoV9tztPFyw==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -289,23 +335,23 @@
         }
       ],
       "license": "MIT",
-      "optional": true,
       "dependencies": {
-        "@csstools/color-helpers": "^5.1.0",
-        "@csstools/css-calc": "^2.1.4"
+        "@csstools/color-helpers": "^6.1.0",
+        "@csstools/css-calc": "^3.3.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20.19.0"
       },
       "peerDependencies": {
-        "@csstools/css-parser-algorithms": "^3.0.5",
-        "@csstools/css-tokenizer": "^3.0.4"
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
       }
     },
     "node_modules/@csstools/css-parser-algorithms": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
-      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -317,18 +363,43 @@
         }
       ],
       "license": "MIT",
-      "optional": true,
       "engines": {
-        "node": ">=18"
+        "node": ">=20.19.0"
       },
       "peerDependencies": {
-        "@csstools/css-tokenizer": "^3.0.4"
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.7.tgz",
+      "integrity": "sha512-fQ+05118eQS1cofO3aJpB5efgpBZMvIzwr/sbC8kDLVA5XLG8q1kJV5yzrUAI1f7lvhPnm8fgIjzFB8/O/5Dig==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
       }
     },
     "node_modules/@csstools/css-tokenizer": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
-      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -340,9 +411,8 @@
         }
       ],
       "license": "MIT",
-      "optional": true,
       "engines": {
-        "node": ">=18"
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@emotion/babel-plugin": {
@@ -994,6 +1064,24 @@
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@fontsource/roboto": {
@@ -2143,6 +2231,63 @@
         "@swc/counter": "^0.1.3"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -2896,6 +3041,17 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -3008,6 +3164,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/bl": {
@@ -3320,6 +3486,20 @@
       ],
       "license": "MIT"
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/cssstyle": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
@@ -3334,6 +3514,142 @@
         "node": ">=18"
       }
     },
+    "node_modules/cssstyle/node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/cssstyle/node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/cssstyle/node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/cssstyle/node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/cssstyle/node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC",
+      "optional": true
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -3341,17 +3657,17 @@
       "license": "MIT"
     },
     "node_modules/data-urls": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
-      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
-        "whatwg-mimetype": "^4.0.0",
-        "whatwg-url": "^14.0.0"
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/debug": {
@@ -3375,8 +3691,8 @@
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
-      "license": "MIT",
-      "optional": true
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/decode-named-character-reference": {
       "version": "1.3.0",
@@ -3499,6 +3815,14 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -3883,6 +4207,153 @@
       "optionalDependencies": {
         "canvas": "^3.2.0",
         "jsdom": "^26.1.0"
+      }
+    },
+    "node_modules/fabric/node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fabric/node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fabric/node_modules/jsdom": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+      "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "cssstyle": "^4.2.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.5.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.16",
+        "parse5": "^7.2.1",
+        "rrweb-cssom": "^0.8.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.1.1",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.1.1",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fabric/node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/fabric/node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/fabric/node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/fabric/node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fabric/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/fabric/node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fabric/node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -4527,16 +4998,16 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/html-encoding-sniffer": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
-      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
-        "whatwg-encoding": "^3.1.1"
+        "@exodus/bytes": "^1.6.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/html-parse-stringify": {
@@ -4847,8 +5318,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
-      "license": "MIT",
-      "optional": true
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -4875,35 +5346,36 @@
       }
     },
     "node_modules/jsdom": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
-      "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
-        "cssstyle": "^4.2.1",
-        "data-urls": "^5.0.0",
-        "decimal.js": "^10.5.0",
-        "html-encoding-sniffer": "^4.0.0",
-        "http-proxy-agent": "^7.0.2",
-        "https-proxy-agent": "^7.0.6",
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
         "is-potential-custom-element-name": "^1.0.1",
-        "nwsapi": "^2.2.16",
-        "parse5": "^7.2.1",
-        "rrweb-cssom": "^0.8.0",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
         "saxes": "^6.0.0",
         "symbol-tree": "^3.2.4",
-        "tough-cookie": "^5.1.1",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
         "w3c-xmlserializer": "^5.0.0",
-        "webidl-conversions": "^7.0.0",
-        "whatwg-encoding": "^3.1.1",
-        "whatwg-mimetype": "^4.0.0",
-        "whatwg-url": "^14.1.1",
-        "ws": "^8.18.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
         "xml-name-validator": "^5.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
       },
       "peerDependencies": {
         "canvas": "^3.0.0"
@@ -4912,6 +5384,32 @@
         "canvas": {
           "optional": true
         }
+      }
+    },
+    "node_modules/jsdom/node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/jsdom/node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/jsesc": {
@@ -5320,6 +5818,27 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -5646,6 +6165,13 @@
         "@mui/material": "^5.0.0 || ^6.0.0 || ^7.0.0",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/memoize-one": {
       "version": "5.2.1",
@@ -6344,9 +6870,9 @@
       }
     },
     "node_modules/nwsapi": {
-      "version": "2.2.23",
-      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
-      "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
+      "version": "2.2.24",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.24.tgz",
+      "integrity": "sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==",
       "license": "MIT",
       "optional": true
     },
@@ -6649,6 +7175,36 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -6838,6 +7394,14 @@
           "optional": true
         }
       }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-markdown": {
       "version": "10.1.0",
@@ -7376,6 +7940,16 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/reselect": {
       "version": "4.1.8",
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.8.tgz",
@@ -7541,8 +8115,8 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
       "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "devOptional": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "xmlchars": "^2.2.0"
       },
@@ -7806,8 +8380,8 @@
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
-      "license": "MIT",
-      "optional": true
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/tar-fs": {
       "version": "2.1.4",
@@ -7906,24 +8480,24 @@
       }
     },
     "node_modules/tldts": {
-      "version": "6.1.86",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
-      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "version": "7.4.9",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.9.tgz",
+      "integrity": "sha512-3kZ8wQQ/k5DrChD4X4FVvr2D7E5uoRgAqkPyLpSCGUvqOvqu+JEdr3mwMUaVWb+vMHZaKhF5fp2PBigKsui7hA==",
+      "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
-        "tldts-core": "^6.1.86"
+        "tldts-core": "^7.4.9"
       },
       "bin": {
         "tldts": "bin/cli.js"
       }
     },
     "node_modules/tldts-core": {
-      "version": "6.1.86",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
-      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
-      "license": "MIT",
-      "optional": true
+      "version": "7.4.9",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.9.tgz",
+      "integrity": "sha512-DxKfPBI52p2msTEu7MPhdpdDTBhhVQg1a/8PjQckeyAvO13eMYElX545grIp6nnTGIMZlRvFZPvFhvI/WIz2Vg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/toposort": {
       "version": "2.0.2",
@@ -7931,29 +8505,29 @@
       "integrity": "sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg=="
     },
     "node_modules/tough-cookie": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
-      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
       "license": "BSD-3-Clause",
-      "optional": true,
       "dependencies": {
-        "tldts": "^6.1.32"
+        "tldts": "^7.0.5"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/tr46": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
-      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "punycode": "^2.3.1"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/trim-lines": {
@@ -8042,6 +8616,16 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -8399,8 +8983,8 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
       "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "xml-name-validator": "^5.0.0"
       },
@@ -8418,13 +9002,13 @@
       }
     },
     "node_modules/webidl-conversions": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
       "license": "BSD-2-Clause",
-      "optional": true,
       "engines": {
-        "node": ">=12"
+        "node": ">=20"
       }
     },
     "node_modules/whatwg-encoding": {
@@ -8442,27 +9026,28 @@
       }
     },
     "node_modules/whatwg-mimetype": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
-      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/whatwg-url": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
-      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
-        "tr46": "^5.1.0",
-        "webidl-conversions": "^7.0.0"
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
       },
       "engines": {
-        "node": ">=18"
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/which": {
@@ -8504,9 +9089,9 @@
       "devOptional": true
     },
     "node_modules/ws": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -8529,8 +9114,8 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
       "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "devOptional": true,
       "license": "Apache-2.0",
-      "optional": true,
       "engines": {
         "node": ">=18"
       }
@@ -8539,8 +9124,8 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
-      "license": "MIT",
-      "optional": true
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/yaml": {
       "version": "2.9.0",

--- a/client/package.json
+++ b/client/package.json
@@ -50,6 +50,7 @@
     "yup": "^1.7.1"
   },
   "devDependencies": {
+    "@testing-library/react": "^16.3.2",
     "@types/chroma-js": "^3.1.2",
     "@types/node": "^22.20.0",
     "@types/react": "^18.3.31",
@@ -61,6 +62,7 @@
     "eslint": "^8.57.1",
     "eslint-plugin-react-hooks": "^4.6.2",
     "eslint-plugin-react-refresh": "^0.4.26",
+    "jsdom": "^29.1.1",
     "prettier": "^3.8.4",
     "typescript": "^6.0.3",
     "vite": "^7.3.5",

--- a/client/src/pages/Exercises/ExerciseList/ExerciseList.test.tsx
+++ b/client/src/pages/Exercises/ExerciseList/ExerciseList.test.tsx
@@ -1,0 +1,198 @@
+// @vitest-environment jsdom
+
+import type {
+  ChangeEventHandler,
+  KeyboardEventHandler,
+  PropsWithChildren,
+  ReactNode,
+} from "react";
+import { act, cleanup, fireEvent, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import ExerciseList from "./ExerciseList";
+
+const { getExercisesMock } = vi.hoisted(() => ({
+  getExercisesMock: vi.fn(),
+}));
+
+vi.mock("./translations", () => ({}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("react-router-dom", () => ({
+  useNavigate: () => vi.fn(),
+}));
+
+vi.mock("../../../store/hooks", () => ({
+  useAuth: () => ({ id: "user-1", name: "Coach", status: null }),
+}));
+
+vi.mock("../../exerciseApi", () => ({
+  useLazyGetExercisesQuery: () => [
+    getExercisesMock,
+    { data: undefined, isError: false, isLoading: false },
+  ],
+  useAddExerciseMutation: () => [
+    vi.fn(() => ({ unwrap: vi.fn() })),
+    { isLoading: false },
+  ],
+}));
+
+vi.mock("../../../components", () => {
+  const MockContainer = ({ children }: PropsWithChildren) => (
+    <div>{children}</div>
+  );
+
+  return {
+    SoftBox: MockContainer,
+    SoftButton: ({ children, onClick, disabled }: PropsWithChildren<{
+      onClick?: () => void;
+      disabled?: boolean;
+    }>) => (
+      <button type="button" onClick={onClick} disabled={disabled}>
+        {children}
+      </button>
+    ),
+    SoftInput: ({
+      id,
+      placeholder,
+      value,
+      onChange,
+      onKeyDown,
+      disabled,
+      type,
+    }: {
+      id?: string;
+      placeholder?: string;
+      value?: string;
+      onChange?: ChangeEventHandler<HTMLInputElement>;
+      onKeyDown?: KeyboardEventHandler<HTMLInputElement>;
+      disabled?: boolean;
+      type?: string;
+    }) => (
+      <input
+        id={id}
+        placeholder={placeholder}
+        value={value}
+        onChange={onChange}
+        onKeyDown={onKeyDown}
+        disabled={disabled}
+        type={type}
+      />
+    ),
+    SoftTypography: MockContainer,
+  };
+});
+
+vi.mock("../../../components/LayoutContainers", () => ({
+  DashboardLayout: ({
+    header,
+    children,
+  }: {
+    header: (scrollTrigger: boolean) => ReactNode;
+    children: (scrollTrigger: boolean) => ReactNode;
+  }) => (
+    <div>
+      {header(false)}
+      {children(false)}
+    </div>
+  ),
+}));
+
+vi.mock("../../../components/Footer", () => ({
+  default: () => null,
+}));
+
+vi.mock("./cardView/ExercisesCardView", () => ({
+  default: () => null,
+}));
+
+vi.mock("@mui/material", () => {
+  const MockContainer = ({ children }: PropsWithChildren) => (
+    <div>{children}</div>
+  );
+
+  return {
+    Alert: MockContainer,
+    Button: MockContainer,
+    Card: MockContainer,
+    CardHeader: ({ title, action }: { title: ReactNode; action: ReactNode }) => (
+      <div>
+        {title}
+        {action}
+      </div>
+    ),
+    Chip: ({ label }: { label: ReactNode }) => <span>{label}</span>,
+    CircularProgress: () => null,
+    Dialog: MockContainer,
+    DialogActions: MockContainer,
+    DialogContent: MockContainer,
+    DialogTitle: MockContainer,
+    FormControl: MockContainer,
+    Grid: MockContainer,
+    InputAdornment: MockContainer,
+    InputLabel: MockContainer,
+    MenuItem: MockContainer,
+    Popover: MockContainer,
+    Select: MockContainer,
+    Slider: () => null,
+    ToggleButton: MockContainer,
+    useMediaQuery: () => true,
+  };
+});
+
+vi.mock("@mui/icons-material/FilterAlt", () => ({ default: () => null }));
+vi.mock("@mui/icons-material/KeyboardReturn", () => ({ default: () => null }));
+vi.mock("@mui/icons-material/Add", () => ({ default: () => null }));
+vi.mock("@mui/icons-material/Close", () => ({ default: () => null }));
+vi.mock("@mui/icons-material/Clear", () => ({ default: () => null }));
+vi.mock("@mui/icons-material/Sort", () => ({ default: () => null }));
+
+describe("ExerciseList live tag filtering", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    getExercisesMock.mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it("sends trimmed transient text, then commits it as an exact tag", async () => {
+    const { container } = render(<ExerciseList />);
+
+    await act(() => vi.advanceTimersByTimeAsync(500));
+    getExercisesMock.mockClear();
+
+    const tagInput = container.querySelector<HTMLInputElement>("#tags-filter");
+    expect(tagInput).not.toBeNull();
+
+    fireEvent.change(tagInput!, { target: { value: "  WaR.*  " } });
+    await act(() => vi.advanceTimersByTimeAsync(500));
+
+    expect(getExercisesMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        tagSearch: "WaR.*",
+        tags: [],
+        tagMode: "all",
+        page: 1,
+      }),
+    );
+
+    fireEvent.keyDown(tagInput!, { key: "Enter" });
+    await act(() => vi.advanceTimersByTimeAsync(500));
+
+    expect(getExercisesMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        tagSearch: undefined,
+        tags: ["WaR.*"],
+        tagMode: "all",
+        page: 1,
+      }),
+    );
+  });
+});

--- a/client/src/pages/Exercises/ExerciseList/ExerciseList.tsx
+++ b/client/src/pages/Exercises/ExerciseList/ExerciseList.tsx
@@ -201,6 +201,7 @@ const ExerciseList = () => {
           filter.maxPersons === maxPersons ? undefined : filter.maxPersons,
         personsMin: filter.minPersons === 0 ? undefined : filter.minPersons,
         search: filter.searchValue,
+        tagSearch: filter.tagInput.trim() || undefined,
         tags: filter.tags,
         tagMode: "all",
         materials: filter.materials,

--- a/client/src/pages/exerciseApi.contract.test.ts
+++ b/client/src/pages/exerciseApi.contract.test.ts
@@ -39,6 +39,7 @@ describe("Exercise collection API contract", () => {
     await store.dispatch(
       exerciseApiSlice.endpoints.getExercises.initiate({
         search: "Press .* [one]",
+        tagSearch: "WaRm .* [up]",
         tags: ["Defense", "Fast play"],
         tagMode: "any",
         materials: ["Hoops", "Cones"],
@@ -59,7 +60,7 @@ describe("Exercise collection API contract", () => {
     );
 
     expect(lastRequest()).toEqual({
-      url: "/api/exercises?search=Press+.*+%5Bone%5D&tags=Defense&tags=Fast+play&tagMode=any&materials=Hoops&materials=Cones&materialMode=all&personsMin=2&personsMax=12&durationMin=5&durationMax=30&beatersMin=1&beatersMax=4&chasersMin=3&chasersMax=6&sort=duration&direction=desc&page=3&limit=25",
+      url: "/api/exercises?search=Press+.*+%5Bone%5D&tagSearch=WaRm+.*+%5Bup%5D&tags=Defense&tags=Fast+play&tagMode=any&materials=Hoops&materials=Cones&materialMode=all&personsMin=2&personsMax=12&durationMin=5&durationMax=30&beatersMin=1&beatersMax=4&chasersMin=3&chasersMax=6&sort=duration&direction=desc&page=3&limit=25",
       method: "get",
     });
   });

--- a/client/src/pages/exerciseApi.ts
+++ b/client/src/pages/exerciseApi.ts
@@ -16,6 +16,7 @@ import {
 
 export type GetExercisesRequest = {
   search?: string;
+  tagSearch?: string;
   tags?: string[];
   tagMode?: "all" | "any";
   materials?: string[];
@@ -187,6 +188,7 @@ export const exerciseApiSlice = quadcoachApi.injectEndpoints({
       query: (request) => {
         const {
           search,
+          tagSearch,
           tags,
           tagMode,
           materials,
@@ -207,6 +209,7 @@ export const exerciseApiSlice = quadcoachApi.injectEndpoints({
         const urlParams = new URLSearchParams();
 
         if (search) urlParams.append("search", search);
+        if (tagSearch) urlParams.append("tagSearch", tagSearch);
         tags?.forEach((tag) => urlParams.append("tags", tag));
         if (tags?.length && tagMode) urlParams.append("tagMode", tagMode);
         materials?.forEach((material) =>

--- a/client/vitest.config.ts
+++ b/client/vitest.config.ts
@@ -3,6 +3,6 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     environment: "node",
-    include: ["src/**/*.test.ts"],
+    include: ["src/**/*.test.{ts,tsx}"],
   },
 });

--- a/server/collectionQuery/index.ts
+++ b/server/collectionQuery/index.ts
@@ -213,8 +213,17 @@ function rangeMatch(range: IntegerRange): mongo.Document {
 function callerMatch(intent: CollectionIntent): mongo.Filter<mongo.Document> {
   const match: mongo.Filter<mongo.Document> = {};
   if (intent.search) match.name = new RegExp(escapeRegex(intent.search), "i");
-  if (intent.tags) match.tags = selectionMatch(intent.tags);
   if (intent.resource === "exercise") {
+    if (intent.tags && intent.tagSearch) {
+      match.$and = [
+        { tags: selectionMatch(intent.tags) },
+        { tags: new RegExp(escapeRegex(intent.tagSearch), "i") },
+      ];
+    } else if (intent.tags) {
+      match.tags = selectionMatch(intent.tags);
+    } else if (intent.tagSearch) {
+      match.tags = new RegExp(escapeRegex(intent.tagSearch), "i");
+    }
     const fields: readonly [
       keyof Pick<
         ExerciseIntent,
@@ -232,8 +241,11 @@ function callerMatch(intent: CollectionIntent): mongo.Filter<mongo.Document> {
       const selectedRange = intent[semanticField];
       if (selectedRange) match[persistenceField] = rangeMatch(selectedRange);
     }
-  } else if (intent.privacy) {
-    match.isPrivate = intent.privacy === "private" ? true : { $ne: true };
+  } else {
+    if (intent.tags) match.tags = selectionMatch(intent.tags);
+    if (intent.privacy) {
+      match.isPrivate = intent.privacy === "private" ? true : { $ne: true };
+    }
   }
   return match;
 }

--- a/server/collectionQuery/parser.ts
+++ b/server/collectionQuery/parser.ts
@@ -58,6 +58,7 @@ const commonFields = new Set([
 ]);
 const exerciseFields = new Set([
   ...commonFields,
+  "tagSearch",
   "materials",
   "materialMode",
   "personsMin",
@@ -256,6 +257,7 @@ export function parseCollectionQuery(
     const intent: ExerciseIntentInput = {
       resource,
       search,
+      tagSearch: singleton(query, "tagSearch", errors),
       tags,
       materials: selectedValues(query, "materials", "materialMode", errors),
       persons: range(query, "persons", errors),

--- a/server/collectionQuery/types.ts
+++ b/server/collectionQuery/types.ts
@@ -32,6 +32,7 @@ export interface ExerciseIntentInput extends CommonIntent<
   CommonSort | "duration" | "persons"
 > {
   readonly resource: "exercise";
+  readonly tagSearch?: string;
   readonly materials?: ValueSelection;
   readonly persons?: IntegerRange;
   readonly duration?: IntegerRange;

--- a/server/tests/contract/collectionQuery.issue145.mongo.contract.spec.ts
+++ b/server/tests/contract/collectionQuery.issue145.mongo.contract.spec.ts
@@ -110,6 +110,59 @@ describe("collection query Mongo contract", () => {
     expect(bounded.items[0]).not.toHaveProperty("description_blocks");
   });
 
+  it("matches exercise tag substrings case-insensitively and literally", async () => {
+    const database = mongoose.connection.db!;
+    await database.collection("exercises").insertMany([
+      { name: "Case match", tags: ["PreWARMup"] },
+      { name: "Literal match", tags: ["Pattern .* drill"] },
+      { name: "Regex-only match", tags: ["Pattern broad drill"] },
+    ]);
+    const visible = collectionVisibility.all();
+
+    const caseInsensitive = await browse({
+      intent: parseCollectionQuery("exercise", { tagSearch: "arm" }),
+      visibility: visible,
+    });
+    expect(caseInsensitive.items.map((item) => item.name)).toEqual([
+      "Case match",
+    ]);
+
+    const literal = await browse({
+      intent: parseCollectionQuery("exercise", { tagSearch: ".*" }),
+      visibility: visible,
+    });
+    expect(literal.items.map((item) => item.name)).toEqual(["Literal match"]);
+  });
+
+  it("intersects exact tags with transient text and preserves page totals", async () => {
+    const database = mongoose.connection.db!;
+    await database.collection("exercises").insertMany([
+      { name: "Both A", tags: ["Conditioning", "Warmup"] },
+      { name: "Both B", tags: ["CONDITIONING", "Pre-warm routine"] },
+      { name: "Exact only", tags: ["Conditioning", "Cooldown"] },
+      { name: "Search only", tags: ["Defense", "Warmup"] },
+    ]);
+
+    const result = await browse({
+      intent: parseCollectionQuery("exercise", {
+        tags: "conditioning",
+        tagMode: "all",
+        tagSearch: "WARM",
+        limit: "1",
+        page: "2",
+      }),
+      visibility: collectionVisibility.all(),
+    });
+
+    expect(result.items.map((item) => item.name)).toEqual(["Both B"]);
+    expect(result.pagination).toEqual({
+      page: 2,
+      limit: 1,
+      total: 2,
+      pages: 2,
+    });
+  });
+
   it("supports stable pages, successful beyond-end pages, and derived plan summaries", async () => {
     const database = mongoose.connection.db!;
     await database.collection("practiceplans").insertMany([

--- a/server/tests/contract/exerciseCollection.issue146.http.contract.spec.ts
+++ b/server/tests/contract/exerciseCollection.issue146.http.contract.spec.ts
@@ -99,6 +99,60 @@ describe("issue 146 Exercise collection HTTP contract", () => {
     });
   });
 
+  it("filters by literal tag text and intersects committed tags", async () => {
+    await mongoose.connection.db!.collection("exercises").insertMany([
+      { name: "Both", tags: ["Conditioning", "PreWARMup .* drill"] },
+      { name: "Exact only", tags: ["Conditioning", "Cooldown"] },
+      { name: "Search only", tags: ["Defense", "Warmup .* drill"] },
+      { name: "Regex syntax is literal", tags: ["Conditioning", "Warmup"] },
+    ]);
+
+    const intersection = await request(app)
+      .get("/api/exercises")
+      .query({
+        tagSearch: "  arm  ",
+        tags: "conditioning",
+        tagMode: "all",
+      })
+      .expect(200);
+    expect(
+      intersection.body.items.map((item: { name: string }) => item.name),
+    ).toEqual(["Both", "Regex syntax is literal"]);
+    expect(intersection.body.pagination).toEqual({
+      page: 1,
+      limit: 50,
+      total: 2,
+      pages: 1,
+    });
+
+    const literal = await request(app)
+      .get("/api/exercises")
+      .query({ tagSearch: ".*", tags: "conditioning" })
+      .expect(200);
+    expect(literal.body.items.map((item: { name: string }) => item.name)).toEqual(
+      ["Both"],
+    );
+  });
+
+  it("returns strict validation envelopes for invalid tag searches", async () => {
+    const duplicate = await request(app)
+      .get("/api/exercises?tagSearch=warm&tagSearch=up")
+      .expect(400);
+    expect(duplicate.body).toEqual({
+      message: "Invalid collection query",
+      errors: [{ field: "tagSearch", code: "duplicate" }],
+    });
+
+    const blank = await request(app)
+      .get("/api/exercises")
+      .query({ tagSearch: " " })
+      .expect(400);
+    expect(blank.body).toEqual({
+      message: "Invalid collection query",
+      errors: [{ field: "tagSearch", code: "blank" }],
+    });
+  });
+
   it("returns strict validation envelopes for legacy and unknown syntax", async () => {
     const response = await request(app)
       .get("/api/exercises?name%5Bregex%5D=x&sortBy=time&limit=101")

--- a/server/tests/unit/collectionQueryParser.issue145.spec.ts
+++ b/server/tests/unit/collectionQueryParser.issue145.spec.ts
@@ -63,6 +63,29 @@ describe("collection query transport parser", () => {
     ]);
   });
 
+  it("normalizes a bounded exercise tag search into frozen semantics", () => {
+    const absent = parseCollectionQuery("exercise", {});
+    expect(absent).toHaveProperty("tagSearch", undefined);
+
+    const boundaryValue = "x".repeat(100);
+    const intent = parseCollectionQuery("exercise", {
+      tagSearch: `  ${boundaryValue}  `,
+    });
+    expect(intent).toMatchObject({ tagSearch: boundaryValue });
+    expect(Object.isFrozen(intent)).toBe(true);
+  });
+
+  it.each([
+    [{ tagSearch: " " }, "blank"],
+    [{ tagSearch: ["first", "second"] }, "duplicate"],
+    [{ tagSearch: { value: "warm" } }, "malformed"],
+    [{ tagSearch: "x".repeat(101) }, "outOfRange"],
+  ] as const)("rejects invalid exercise tag search %#", (query, code) => {
+    expect(errorsFor("exercise", query).errors).toEqual([
+      { field: "tagSearch", code },
+    ]);
+  });
+
   it("accepts repeated unique sets and rejects malformed ranges", () => {
     expect(
       parseCollectionQuery("exercise", {
@@ -111,6 +134,12 @@ describe("collection query transport parser", () => {
     ]);
     expect(errorsFor("exercise", { materialMode: "any" }).errors).toEqual([
       { field: "materialMode", code: "unsupported" },
+    ]);
+    expect(errorsFor("tacticBoard", { tagSearch: "warm" }).errors).toEqual([
+      { field: "tagSearch", code: "unknown" },
+    ]);
+    expect(errorsFor("practicePlan", { tagSearch: "warm" }).errors).toEqual([
+      { field: "tagSearch", code: "unknown" },
     ]);
   });
 


### PR DESCRIPTION
[#152](https://github.com/wienans/quadcoach/issues/152) | [Artifacts](https://cloud.humanlayer.com/artifacts/019fad6e-7c88-7be4-a546-b7ab33392d15) | [PR Walkthrough (alpha)](https://cloud.humanlayer.com/artifacts/019fad99-79e6-7c76-8eb8-ff23e1d911e7)

## What problems was I solving

The exercise browser refreshed after a coach typed into the tag filter, but the transient text was omitted from the server-backed collection request. Results therefore stayed unfiltered until Enter converted the text into a committed tag chip.

This PR restores live filtering after the existing 500 ms debounce while preserving the strict collection-query contract introduced by the exercise browsing migration. Transient text is trimmed and matched as a literal, case-insensitive substring; committed chips retain their exact, case-insensitive `all` semantics. When both are present, both predicates must match.

## What user-facing changes did I ship

- [ExerciseList.tsx](https://github.com/wienans/quadcoach/pull/153/files#diff-6666722e7ee3ccea14549320ee153324a9e1b6a284f86b6fbe7df5d341f281fa) - Exercise results now narrow while the coach types in the tag field, without waiting for Enter.
- [collectionQuery/index.ts](https://github.com/wienans/quadcoach/pull/153/files#diff-ff1957abf36bd7d92d9ef0445af14c57d1fa7a499bd9899cb111ae755cc6a14f) - Live text matches tag substrings case-insensitively and treats regex characters such as `.*` literally.
- [exerciseCollection.issue146.http.contract.spec.ts](https://github.com/wienans/quadcoach/pull/153/files#diff-04c9e76710caa318da808572f7e20e7f5273df72d0691f4aac7c5369f14e5392) - The HTTP contract protects intersections between live text and committed chips, pagination metadata, and invalid-input responses.

## How I implemented it

### Backend Changes

- [types.ts](https://github.com/wienans/quadcoach/pull/153/files#diff-ad22cabe94f5c077a4274e20358d8a894ca5cb3885291e25a14a5966dcd28fb6) - Adds the exercise-only `tagSearch` field without changing the common collection intent shared by other resources.
- [parser.ts](https://github.com/wienans/quadcoach/pull/153/files#diff-0d36ab5e11ce7e3d5a658e7ba6e6a98d17f91d6fea2a59d54163b4252ca5077c) - Whitelists `tagSearch` for exercises and routes it through existing singleton normalization and bounds validation.
- [collectionQuery/index.ts](https://github.com/wienans/quadcoach/pull/153/files#diff-ff1957abf36bd7d92d9ef0445af14c57d1fa7a499bd9899cb111ae755cc6a14fR216) - Builds an escaped case-insensitive regex for transient text and uses `$and` when exact chips and live text coexist.
- [collectionQueryParser.issue145.spec.ts](https://github.com/wienans/quadcoach/pull/153/files#diff-a651e92c6992c371bf07f43c621812df1d3e20b839cbc3b69dbc7330fc024646) - Covers trimming, the 100-character boundary, invalid shapes, and exercise-only resource scoping.
- [collectionQuery.issue145.mongo.contract.spec.ts](https://github.com/wienans/quadcoach/pull/153/files#diff-a7404c67308b685382f23d6c86bcf5f5b2116f6c7b3c012e11619341e026cdc1) - Verifies literal substring matching, case folding, exact-chip intersections, and stable pagination totals at the Mongo boundary.

### Frontend Changes

- [exerciseApi.ts](https://github.com/wienans/quadcoach/pull/153/files#diff-c30b87129f54bbececd0d228fcb559b098c7ebd7cd70a36b2b23fe950be04d69) - Extends the typed request and serializes `tagSearch` as its own query parameter.
- [ExerciseList.tsx](https://github.com/wienans/quadcoach/pull/153/files#diff-6666722e7ee3ccea14549320ee153324a9e1b6a284f86b6fbe7df5d341f281faR204) - Connects trimmed `filter.tagInput` to the existing debounced collection request; blank input remains omitted.
- [ExerciseList.test.tsx](https://github.com/wienans/quadcoach/pull/153/files#diff-6cda09b5c390491f05055608c5f43d549760aeee02e6dfc850dc1ebcd727128a) - Advances fake timers through the real debounce, then verifies the transition from transient text to a committed exact chip after Enter.
- [vitest.config.ts](https://github.com/wienans/quadcoach/pull/153/files#diff-d8ce1eb39fca4e3914bd218c4046122183e6bc62563d44f74e823bca390c524c) - Includes TSX component tests in Vitest discovery, backed by Testing Library and jsdom development dependencies.

## Deviations from the plan

No plan file was found. The implementation follows the approved structure outline: establish the validated server contract first, connect the existing debounced UI flow second, and protect the behavior at client serialization, parser, Mongo, HTTP, and component boundaries.

## How to verify it

### Worktree Setup

```bash
git fetch origin
git switch wienans-quadcoach-152-tag-filtering-doesnt-work-anymore-while-typing
git pull --ff-only
```

### Manual Testing

- [ ] Open the exercise list and type part of an existing tag; confirm results narrow after roughly 500 ms without pressing Enter.
- [ ] Type mixed-case text and confirm matching is case-insensitive.
- [ ] Type regex characters such as `.*` and confirm they are treated as literal tag text.
- [ ] Commit a tag with Enter, then type another partial tag; confirm both the chip and transient text narrow the result together.
- [ ] Clear the transient text and committed chips; confirm the full visible exercise collection returns and pagination remains correct.

### Automated Tests

```bash
cd client && npm test
cd ../server && npm test -- --runTestsByPath \
  tests/unit/collectionQueryParser.issue145.spec.ts \
  tests/contract/collectionQuery.issue145.mongo.contract.spec.ts \
  tests/contract/exerciseCollection.issue146.http.contract.spec.ts
```

Verified locally: 38 client tests and 31 targeted server tests pass.

## Description for the changelog

Restore debounced, case-insensitive exercise tag filtering while typing, with committed tag chips continuing to narrow results exactly.
