### PR TITLE
Restore live exercise tag filtering

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -44,6 +44,8 @@
         "yup": "^1.7.1"
       },
       "devDependencies": {
+        "@testing-library/jest-dom": "^7.0.0",
+        "@testing-library/react": "^16.3.2",
         "@types/chroma-js": "^3.1.2",
         "@types/node": "^22.20.0",
         "@types/react": "^18.3.31",
@@ -55,6 +57,7 @@
         "eslint": "^8.57.1",
         "eslint-plugin-react-hooks": "^4.6.2",
         "eslint-plugin-react-refresh": "^0.4.26",
+        "jsdom": "^29.1.1",
         "prettier": "^3.8.4",
         "typescript": "^6.0.3",
         "vite": "^7.3.5",
@@ -70,26 +73,63 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+      "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@asamuzakjp/css-color": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
-      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
-        "@csstools/css-calc": "^2.1.3",
-        "@csstools/css-color-parser": "^3.0.9",
-        "@csstools/css-parser-algorithms": "^3.0.4",
-        "@csstools/css-tokenizer": "^3.0.3",
-        "lru-cache": "^10.4.3"
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
-    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "license": "ISC",
-      "optional": true
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
@@ -230,10 +270,24 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
     "node_modules/@csstools/color-helpers": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
-      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
+      "integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -245,15 +299,15 @@
         }
       ],
       "license": "MIT-0",
-      "optional": true,
       "engines": {
-        "node": ">=18"
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@csstools/css-calc": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
-      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+      "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -265,19 +319,19 @@
         }
       ],
       "license": "MIT",
-      "optional": true,
       "engines": {
-        "node": ">=18"
+        "node": ">=20.19.0"
       },
       "peerDependencies": {
-        "@csstools/css-parser-algorithms": "^3.0.5",
-        "@csstools/css-tokenizer": "^3.0.4"
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
       }
     },
     "node_modules/@csstools/css-color-parser": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
-      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.10.tgz",
+      "integrity": "sha512-UZhQLIUyJaaMepqehrCODwCg2KW25vFvLWBmqYFaPclYvvxzj/sG8LBOhBFCp11i9uE7t1EyS+RAoV9tztPFyw==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -289,23 +343,23 @@
         }
       ],
       "license": "MIT",
-      "optional": true,
       "dependencies": {
-        "@csstools/color-helpers": "^5.1.0",
-        "@csstools/css-calc": "^2.1.4"
+        "@csstools/color-helpers": "^6.1.0",
+        "@csstools/css-calc": "^3.3.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20.19.0"
       },
       "peerDependencies": {
-        "@csstools/css-parser-algorithms": "^3.0.5",
-        "@csstools/css-tokenizer": "^3.0.4"
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
       }
     },
     "node_modules/@csstools/css-parser-algorithms": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
-      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -317,18 +371,43 @@
         }
       ],
       "license": "MIT",
-      "optional": true,
       "engines": {
-        "node": ">=18"
+        "node": ">=20.19.0"
       },
       "peerDependencies": {
-        "@csstools/css-tokenizer": "^3.0.4"
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.7.tgz",
+      "integrity": "sha512-fQ+05118eQS1cofO3aJpB5efgpBZMvIzwr/sbC8kDLVA5XLG8q1kJV5yzrUAI1f7lvhPnm8fgIjzFB8/O/5Dig==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
       }
     },
     "node_modules/@csstools/css-tokenizer": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
-      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -340,9 +419,8 @@
         }
       ],
       "license": "MIT",
-      "optional": true,
       "engines": {
-        "node": ">=18"
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@emotion/babel-plugin": {
@@ -994,6 +1072,24 @@
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@fontsource/roboto": {
@@ -2143,6 +2239,93 @@
         "@swc/counter": "^0.1.3"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-7.0.0.tgz",
+      "integrity": "sha512-HKAH9C6mBo5yBG6yRO5i43L2iisencAo5z+o5P/saHUoY+miC5ivXRxHBJcFyB5ypPNxHJdK3BoF/3O4DIptMg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=22",
+        "npm": ">=6",
+        "yarn": ">=1"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=10 <11"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -2896,6 +3079,16 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -3008,6 +3201,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/bl": {
@@ -3320,6 +3523,27 @@
       ],
       "license": "MIT"
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cssstyle": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
@@ -3334,6 +3558,142 @@
         "node": ">=18"
       }
     },
+    "node_modules/cssstyle/node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/cssstyle/node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/cssstyle/node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/cssstyle/node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/cssstyle/node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC",
+      "optional": true
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -3341,17 +3701,17 @@
       "license": "MIT"
     },
     "node_modules/data-urls": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
-      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
-        "whatwg-mimetype": "^4.0.0",
-        "whatwg-url": "^14.0.0"
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/debug": {
@@ -3375,8 +3735,8 @@
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
-      "license": "MIT",
-      "optional": true
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/decode-named-character-reference": {
       "version": "1.3.0",
@@ -3499,6 +3859,14 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -3883,6 +4251,153 @@
       "optionalDependencies": {
         "canvas": "^3.2.0",
         "jsdom": "^26.1.0"
+      }
+    },
+    "node_modules/fabric/node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fabric/node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fabric/node_modules/jsdom": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+      "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "cssstyle": "^4.2.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.5.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.16",
+        "parse5": "^7.2.1",
+        "rrweb-cssom": "^0.8.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.1.1",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.1.1",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fabric/node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/fabric/node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/fabric/node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/fabric/node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fabric/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/fabric/node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fabric/node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -4527,16 +5042,16 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/html-encoding-sniffer": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
-      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
-        "whatwg-encoding": "^3.1.1"
+        "@exodus/bytes": "^1.6.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/html-parse-stringify": {
@@ -4708,6 +5223,16 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -4847,8 +5372,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
-      "license": "MIT",
-      "optional": true
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -4875,35 +5400,36 @@
       }
     },
     "node_modules/jsdom": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
-      "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
-        "cssstyle": "^4.2.1",
-        "data-urls": "^5.0.0",
-        "decimal.js": "^10.5.0",
-        "html-encoding-sniffer": "^4.0.0",
-        "http-proxy-agent": "^7.0.2",
-        "https-proxy-agent": "^7.0.6",
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
         "is-potential-custom-element-name": "^1.0.1",
-        "nwsapi": "^2.2.16",
-        "parse5": "^7.2.1",
-        "rrweb-cssom": "^0.8.0",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
         "saxes": "^6.0.0",
         "symbol-tree": "^3.2.4",
-        "tough-cookie": "^5.1.1",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
         "w3c-xmlserializer": "^5.0.0",
-        "webidl-conversions": "^7.0.0",
-        "whatwg-encoding": "^3.1.1",
-        "whatwg-mimetype": "^4.0.0",
-        "whatwg-url": "^14.1.1",
-        "ws": "^8.18.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
         "xml-name-validator": "^5.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
       },
       "peerDependencies": {
         "canvas": "^3.0.0"
@@ -4912,6 +5438,32 @@
         "canvas": {
           "optional": true
         }
+      }
+    },
+    "node_modules/jsdom/node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/jsdom/node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/jsesc": {
@@ -5320,6 +5872,27 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -5646,6 +6219,13 @@
         "@mui/material": "^5.0.0 || ^6.0.0 || ^7.0.0",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/memoize-one": {
       "version": "5.2.1",
@@ -6244,6 +6824,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -6344,9 +6934,9 @@
       }
     },
     "node_modules/nwsapi": {
-      "version": "2.2.23",
-      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
-      "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
+      "version": "2.2.24",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.24.tgz",
+      "integrity": "sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==",
       "license": "MIT",
       "optional": true
     },
@@ -6649,6 +7239,36 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -6838,6 +7458,14 @@
           "optional": true
         }
       }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-markdown": {
       "version": "10.1.0",
@@ -7054,6 +7682,20 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/redux": {
@@ -7376,6 +8018,16 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/reselect": {
       "version": "4.1.8",
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.8.tgz",
@@ -7541,8 +8193,8 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
       "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "devOptional": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "xmlchars": "^2.2.0"
       },
@@ -7742,6 +8394,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -7806,8 +8471,8 @@
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
-      "license": "MIT",
-      "optional": true
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/tar-fs": {
       "version": "2.1.4",
@@ -7906,24 +8571,24 @@
       }
     },
     "node_modules/tldts": {
-      "version": "6.1.86",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
-      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "version": "7.4.9",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.9.tgz",
+      "integrity": "sha512-3kZ8wQQ/k5DrChD4X4FVvr2D7E5uoRgAqkPyLpSCGUvqOvqu+JEdr3mwMUaVWb+vMHZaKhF5fp2PBigKsui7hA==",
+      "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
-        "tldts-core": "^6.1.86"
+        "tldts-core": "^7.4.9"
       },
       "bin": {
         "tldts": "bin/cli.js"
       }
     },
     "node_modules/tldts-core": {
-      "version": "6.1.86",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
-      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
-      "license": "MIT",
-      "optional": true
+      "version": "7.4.9",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.9.tgz",
+      "integrity": "sha512-DxKfPBI52p2msTEu7MPhdpdDTBhhVQg1a/8PjQckeyAvO13eMYElX545grIp6nnTGIMZlRvFZPvFhvI/WIz2Vg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/toposort": {
       "version": "2.0.2",
@@ -7931,29 +8596,29 @@
       "integrity": "sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg=="
     },
     "node_modules/tough-cookie": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
-      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
       "license": "BSD-3-Clause",
-      "optional": true,
       "dependencies": {
-        "tldts": "^6.1.32"
+        "tldts": "^7.0.5"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/tr46": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
-      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "punycode": "^2.3.1"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/trim-lines": {
@@ -8042,6 +8707,16 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -8399,8 +9074,8 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
       "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "xml-name-validator": "^5.0.0"
       },
@@ -8418,13 +9093,13 @@
       }
     },
     "node_modules/webidl-conversions": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
       "license": "BSD-2-Clause",
-      "optional": true,
       "engines": {
-        "node": ">=12"
+        "node": ">=20"
       }
     },
     "node_modules/whatwg-encoding": {
@@ -8442,27 +9117,28 @@
       }
     },
     "node_modules/whatwg-mimetype": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
-      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/whatwg-url": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
-      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
-        "tr46": "^5.1.0",
-        "webidl-conversions": "^7.0.0"
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
       },
       "engines": {
-        "node": ">=18"
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/which": {
@@ -8504,9 +9180,9 @@
       "devOptional": true
     },
     "node_modules/ws": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -8529,8 +9205,8 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
       "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "devOptional": true,
       "license": "Apache-2.0",
-      "optional": true,
       "engines": {
         "node": ">=18"
       }
@@ -8539,8 +9215,8 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
-      "license": "MIT",
-      "optional": true
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/yaml": {
       "version": "2.9.0",

--- a/client/package.json
+++ b/client/package.json
@@ -50,6 +50,8 @@
     "yup": "^1.7.1"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^7.0.0",
+    "@testing-library/react": "^16.3.2",
     "@types/chroma-js": "^3.1.2",
     "@types/node": "^22.20.0",
     "@types/react": "^18.3.31",
@@ -61,6 +63,7 @@
     "eslint": "^8.57.1",
     "eslint-plugin-react-hooks": "^4.6.2",
     "eslint-plugin-react-refresh": "^0.4.26",
+    "jsdom": "^29.1.1",
     "prettier": "^3.8.4",
     "typescript": "^6.0.3",
     "vite": "^7.3.5",

--- a/client/src/pages/Exercises/ExerciseList/ExerciseList.test.tsx
+++ b/client/src/pages/Exercises/ExerciseList/ExerciseList.test.tsx
@@ -1,0 +1,298 @@
+// @vitest-environment jsdom
+
+import "@testing-library/jest-dom/vitest";
+import type {
+  ChangeEventHandler,
+  KeyboardEventHandler,
+  PropsWithChildren,
+  ReactNode,
+} from "react";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ExerciseSummary } from "../../../api/quadcoachApi/domain";
+import type { GetExercisesResponse } from "../../exerciseApi";
+
+import ExerciseList from "./ExerciseList";
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (error: unknown) => void;
+};
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+function exercise(id: string, name: string): ExerciseSummary {
+  return {
+    _id: id,
+    name,
+    tags: [],
+    materials: [],
+    durationMinutes: null,
+    persons: null,
+    beaters: null,
+    chasers: null,
+    relatedTo: [],
+  };
+}
+
+function page(items: ExerciseSummary[]): GetExercisesResponse {
+  return {
+    items,
+    pagination: {
+      page: 1,
+      limit: 50,
+      total: items.length,
+      pages: 1,
+    },
+  };
+}
+
+const { getExercisesMock } = vi.hoisted(() => ({
+  getExercisesMock: vi.fn(),
+}));
+
+const requests: Array<{
+  deferred: Deferred<GetExercisesResponse>;
+  abort: ReturnType<typeof vi.fn>;
+}> = [];
+
+vi.mock("./translations", () => ({}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("react-router-dom", () => ({
+  useNavigate: () => vi.fn(),
+}));
+
+vi.mock("../../../store/hooks", () => ({
+  useAuth: () => ({ id: "user-1", name: "Coach", status: null }),
+}));
+
+vi.mock("../../exerciseApi", () => ({
+  useLazyGetExercisesQuery: () => [getExercisesMock],
+  useAddExerciseMutation: () => [
+    vi.fn(() => ({ unwrap: vi.fn() })),
+    { isLoading: false },
+  ],
+}));
+
+vi.mock("../../../components", () => {
+  const MockContainer = ({ children }: PropsWithChildren) => (
+    <div>{children}</div>
+  );
+
+  return {
+    SoftBox: MockContainer,
+    SoftButton: ({
+      children,
+      onClick,
+      disabled,
+    }: PropsWithChildren<{
+      onClick?: () => void;
+      disabled?: boolean;
+    }>) => (
+      <button type="button" onClick={onClick} disabled={disabled}>
+        {children}
+      </button>
+    ),
+    SoftInput: ({
+      id,
+      placeholder,
+      value,
+      onChange,
+      onKeyDown,
+      disabled,
+      type,
+    }: {
+      id?: string;
+      placeholder?: string;
+      value?: string;
+      onChange?: ChangeEventHandler<HTMLInputElement>;
+      onKeyDown?: KeyboardEventHandler<HTMLInputElement>;
+      disabled?: boolean;
+      type?: string;
+    }) => (
+      <input
+        id={id}
+        placeholder={placeholder}
+        value={value}
+        onChange={onChange}
+        onKeyDown={onKeyDown}
+        disabled={disabled}
+        type={type}
+      />
+    ),
+    SoftTypography: MockContainer,
+  };
+});
+
+vi.mock("../../../components/LayoutContainers", () => ({
+  DashboardLayout: ({
+    header,
+    children,
+  }: {
+    header: (scrollTrigger: boolean) => ReactNode;
+    children: (scrollTrigger: boolean) => ReactNode;
+  }) => (
+    <div>
+      {header(false)}
+      {children(false)}
+    </div>
+  ),
+}));
+
+vi.mock("../../../components/Footer", () => ({
+  default: () => null,
+}));
+
+vi.mock("./cardView/ExercisesCardView", () => ({
+  default: ({
+    exercises,
+    isExercisesLoading,
+  }: {
+    exercises: ExerciseSummary[];
+    isExercisesLoading: boolean;
+  }) => (
+    <div data-testid="exercise-results">
+      {isExercisesLoading
+        ? "loading"
+        : exercises.map((item) => item.name).join(",") || "empty"}
+    </div>
+  ),
+}));
+
+vi.mock("@mui/material", () => {
+  const MockContainer = ({ children }: PropsWithChildren) => (
+    <div>{children}</div>
+  );
+
+  return {
+    Alert: ({ children }: PropsWithChildren) => <div role="alert">{children}</div>,
+    Button: MockContainer,
+    Card: MockContainer,
+    CardHeader: ({ title, action }: { title: ReactNode; action: ReactNode }) => (
+      <div>
+        {title}
+        {action}
+      </div>
+    ),
+    Chip: ({ label }: { label: ReactNode }) => <span>{label}</span>,
+    CircularProgress: () => null,
+    Dialog: MockContainer,
+    DialogActions: MockContainer,
+    DialogContent: MockContainer,
+    DialogTitle: MockContainer,
+    FormControl: MockContainer,
+    Grid: MockContainer,
+    InputAdornment: MockContainer,
+    InputLabel: MockContainer,
+    MenuItem: MockContainer,
+    Popover: MockContainer,
+    Select: MockContainer,
+    Slider: () => null,
+    ToggleButton: MockContainer,
+    useMediaQuery: () => true,
+  };
+});
+
+vi.mock("@mui/icons-material/FilterAlt", () => ({ default: () => null }));
+vi.mock("@mui/icons-material/KeyboardReturn", () => ({ default: () => null }));
+vi.mock("@mui/icons-material/Add", () => ({ default: () => null }));
+vi.mock("@mui/icons-material/Close", () => ({ default: () => null }));
+vi.mock("@mui/icons-material/Clear", () => ({ default: () => null }));
+vi.mock("@mui/icons-material/Sort", () => ({ default: () => null }));
+
+describe("ExerciseList live tag filtering", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    requests.length = 0;
+    getExercisesMock.mockReset();
+    getExercisesMock.mockImplementation(() => {
+      const request = {
+        deferred: deferred<GetExercisesResponse>(),
+        abort: vi.fn(),
+      };
+      requests.push(request);
+      return {
+        abort: request.abort,
+        unwrap: () => request.deferred.promise,
+      };
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it("wires typed, committed, cleared, loading, and generation-safe states", async () => {
+    const { container } = render(<ExerciseList />);
+    expect(screen.getByTestId("exercise-results")).toHaveTextContent("loading");
+
+    act(() => vi.advanceTimersByTime(500));
+    await act(async () => requests[0].deferred.resolve(page([])));
+    expect(screen.getByTestId("exercise-results")).toHaveTextContent("empty");
+
+    const tagInput = container.querySelector<HTMLInputElement>("#tags-filter");
+    expect(tagInput).not.toBeNull();
+    fireEvent.change(tagInput!, { target: { value: "  fen  " } });
+    expect(screen.getByTestId("exercise-results")).toHaveTextContent("loading");
+    act(() => vi.advanceTimersByTime(499));
+    expect(getExercisesMock).toHaveBeenCalledTimes(1);
+    act(() => vi.advanceTimersByTime(1));
+    expect(getExercisesMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ tagSearch: "fen", tags: [], page: 1 }),
+    );
+    expect(screen.getByTestId("exercise-results")).toHaveTextContent("loading");
+
+    await act(async () =>
+      requests[1].deferred.resolve(page([exercise("1", "Defense drill")]))
+    );
+    expect(screen.getByTestId("exercise-results")).toHaveTextContent(
+      "Defense drill",
+    );
+
+    fireEvent.keyDown(tagInput!, { key: "Enter" });
+    expect(screen.getByTestId("exercise-results")).toHaveTextContent("loading");
+    act(() => vi.advanceTimersByTime(500));
+    expect(getExercisesMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        tagSearch: undefined,
+        tags: ["fen"],
+        tagMode: "all",
+        page: 1,
+      }),
+    );
+    await act(async () =>
+      requests[2].deferred.resolve(page([exercise("2", "Exact fen")]))
+    );
+
+    fireEvent.change(tagInput!, { target: { value: "old" } });
+    act(() => vi.advanceTimersByTime(500));
+    fireEvent.change(tagInput!, { target: { value: "" } });
+    expect(requests[3].abort).toHaveBeenCalledOnce();
+    act(() => vi.advanceTimersByTime(500));
+    expect(getExercisesMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ tagSearch: undefined, tags: ["fen"] }),
+    );
+
+    await act(async () => requests[3].deferred.reject(new Error("obsolete")));
+    expect(screen.getByTestId("exercise-results")).toHaveTextContent("loading");
+    await act(async () => requests[4].deferred.reject(new Error("active")));
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "ExerciseList:errorLoadingExercises",
+    );
+  });
+});

--- a/client/src/pages/Exercises/ExerciseList/ExerciseList.tsx
+++ b/client/src/pages/Exercises/ExerciseList/ExerciseList.tsx
@@ -1,9 +1,7 @@
 import "./translations";
 import {
   ChangeEvent,
-  useEffect,
   useState,
-  useCallback,
   KeyboardEvent,
 } from "react";
 import {
@@ -51,36 +49,18 @@ import {
 import { DashboardLayout } from "../../../components/LayoutContainers";
 import { useAuth } from "../../../store/hooks";
 import Footer from "../../../components/Footer";
-import debounce from "lodash/debounce";
-import { Exercise, ExerciseSummary } from "../../../api/quadcoachApi/domain";
-
-const maxPersons = 20; // Maximum number of persons for filtering
-const maxTime = 60; // Maximum time in minutes
-const maxChasers = 10; // Maximum number of chasers
-const maxBeaters = 10; // Maximum number of beaters
-
-type ExerciseFilter = {
-  searchValue: string;
-  minPersons: number;
-  maxPersons: number;
-  tagInput: string;
-  tags: string[];
-  materialInput: string;
-  materials: string[];
-  minTime: number;
-  maxTime: number;
-  minBeaters: number;
-  maxBeaters: number;
-  minChasers: number;
-  maxChasers: number;
-  sort: "name" | "duration" | "persons" | "created" | "updated";
-  direction: "asc" | "desc";
-  page: number;
-  limit: number;
-};
+import { Exercise } from "../../../api/quadcoachApi/domain";
+import {
+  ExerciseFilter,
+  MAX_BEATERS,
+  MAX_CHASERS,
+  MAX_PERSONS,
+  MAX_TIME,
+  useExerciseListQuery,
+} from "./useExerciseListQuery";
 
 const defaultExerciseFilter: ExerciseFilter = {
-  maxPersons: maxPersons,
+  maxPersons: MAX_PERSONS,
   minPersons: 0,
   searchValue: "",
   tagInput: "",
@@ -88,14 +68,13 @@ const defaultExerciseFilter: ExerciseFilter = {
   materialInput: "",
   materials: [],
   minTime: 0,
-  maxTime: maxTime,
+  maxTime: MAX_TIME,
   minBeaters: 0,
-  maxBeaters: maxBeaters,
+  maxBeaters: MAX_BEATERS,
   minChasers: 0,
-  maxChasers: maxChasers,
+  maxChasers: MAX_CHASERS,
   sort: "name",
   direction: "asc",
-  page: 1,
   limit: 50,
 };
 
@@ -109,7 +88,6 @@ const ExerciseList = () => {
     null,
   );
   const { id: userId, name: userName, status: userStatus } = useAuth();
-  const [loadedExercises, setLoadedExercises] = useState<ExerciseSummary[]>([]);
   const [openAddDialog, setOpenAddDialog] = useState(false);
   const [newExerciseName, setNewExerciseName] = useState("");
 
@@ -120,40 +98,33 @@ const ExerciseList = () => {
   const onExerciseFilterValueChange =
     (exerciseFilterProperty: keyof ExerciseFilter) =>
     (event: ChangeEvent<HTMLInputElement>) => {
-      setLoadedExercises([]);
       setExerciseFilter({
         ...exerciseFilter,
         [exerciseFilterProperty]: event.target.value,
-        page: 1,
       });
     };
 
   const handleTagKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
     if (event.key === "Enter" && exerciseFilter.tagInput.trim() !== "") {
       event.preventDefault();
-      setLoadedExercises([]);
       setExerciseFilter({
         ...exerciseFilter,
         tags: [...exerciseFilter.tags, exerciseFilter.tagInput.trim()],
         tagInput: "",
-        page: 1,
       });
     }
   };
 
   const handleDeleteTag = (tagToDelete: string) => {
-    setLoadedExercises([]);
     setExerciseFilter({
       ...exerciseFilter,
       tags: exerciseFilter.tags.filter((tag) => tag !== tagToDelete),
-      page: 1,
     });
   };
 
   const handleMaterialKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
     if (event.key === "Enter" && exerciseFilter.materialInput.trim() !== "") {
       event.preventDefault();
-      setLoadedExercises([]);
       setExerciseFilter({
         ...exerciseFilter,
         materials: [
@@ -161,84 +132,38 @@ const ExerciseList = () => {
           exerciseFilter.materialInput.trim(),
         ],
         materialInput: "",
-        page: 1,
       });
     }
   };
 
   const handleDeleteMaterial = (materialToDelete: string) => {
-    setLoadedExercises([]);
     setExerciseFilter({
       ...exerciseFilter,
       materials: exerciseFilter.materials.filter(
         (material) => material !== materialToDelete,
       ),
-      page: 1,
     });
   };
 
   const handleClearAllFilters = () => {
-    setLoadedExercises([]);
     setExerciseFilter({
       ...defaultExerciseFilter,
     });
   };
 
-  const [
+  const [getExercises] = useLazyGetExercisesQuery();
+  const {
+    exercises: loadedExercises,
+    pagination,
+    status: exerciseQueryStatus,
+    isLoadingMore,
+    loadMore,
+  } = useExerciseListQuery({
+    filter: exerciseFilter,
     getExercises,
-    {
-      data: exercisesData,
-      isError: isExercisesError,
-      isLoading: isExercisesLoading,
-    },
-  ] = useLazyGetExercisesQuery();
-
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const debouncedGetExercises = useCallback(
-    debounce((filter: ExerciseFilter) => {
-      getExercises({
-        personsMax:
-          filter.maxPersons === maxPersons ? undefined : filter.maxPersons,
-        personsMin: filter.minPersons === 0 ? undefined : filter.minPersons,
-        search: filter.searchValue,
-        tags: filter.tags,
-        tagMode: "all",
-        materials: filter.materials,
-        materialMode: "all",
-        durationMin: filter.minTime === 0 ? undefined : filter.minTime,
-        durationMax: filter.maxTime === maxTime ? undefined : filter.maxTime,
-        beatersMin: filter.minBeaters === 0 ? undefined : filter.minBeaters,
-        beatersMax:
-          filter.maxBeaters === maxBeaters ? undefined : filter.maxBeaters,
-        chasersMin: filter.minChasers === 0 ? undefined : filter.minChasers,
-        chasersMax:
-          filter.maxChasers === maxChasers ? undefined : filter.maxChasers,
-        sort: filter.sort,
-        direction: filter.direction,
-        page: filter.page,
-        limit: filter.limit,
-      });
-    }, 500),
-    [getExercises],
-  );
-
-  useEffect(() => {
-    debouncedGetExercises(exerciseFilter);
-
-    return () => {
-      debouncedGetExercises.cancel();
-    };
-  }, [exerciseFilter, debouncedGetExercises]);
-
-  useEffect(() => {
-    if (exercisesData?.items) {
-      setLoadedExercises((prev) => {
-        const newExerciseIds = new Set(exercisesData.items.map((e) => e._id));
-        const filteredPrev = prev.filter((e) => !newExerciseIds.has(e._id));
-        return [...filteredPrev, ...exercisesData.items];
-      });
-    }
-  }, [exercisesData]);
+  });
+  const isExercisesError = exerciseQueryStatus === "error";
+  const isExercisesLoading = exerciseQueryStatus === "loading";
 
   const [createExercise, { isLoading: isCreatingExercise }] =
     useAddExerciseMutation();
@@ -271,23 +196,6 @@ const ExerciseList = () => {
   const onOpenExerciseClick = (exerciseId: string) => {
     navigate(`/exercises/${exerciseId}`);
   };
-
-  // Load more function
-  const loadMore = useCallback(() => {
-    if (exercisesData && exerciseFilter.page < exercisesData.pagination.pages) {
-      setExerciseFilter((prev) => ({
-        ...prev,
-        page: prev.page + 1,
-      }));
-    }
-  }, [exercisesData, exerciseFilter.page]);
-
-  // Add cleanup effect
-  useEffect(() => {
-    return () => {
-      setLoadedExercises([]); // Clear exercises when component unmounts
-    };
-  }, []);
 
   return (
     <DashboardLayout
@@ -366,7 +274,6 @@ const ExerciseList = () => {
                     value={exerciseFilter.sort}
                     label={t("ExerciseList:filter.sort.name")}
                     onChange={(event) => {
-                      setLoadedExercises([]);
                       setExerciseFilter({
                         ...exerciseFilter,
                         sort: event.target.value as
@@ -375,7 +282,6 @@ const ExerciseList = () => {
                           | "persons"
                           | "created"
                           | "updated",
-                        page: 1,
                       });
                     }}
                   >
@@ -400,12 +306,10 @@ const ExerciseList = () => {
                   value={exerciseFilter.direction}
                   selected={exerciseFilter.direction === "desc"}
                   onChange={() => {
-                    setLoadedExercises([]);
                     setExerciseFilter({
                       ...exerciseFilter,
                       direction:
                         exerciseFilter.direction === "asc" ? "desc" : "asc",
-                      page: 1,
                     });
                   }}
                   size="small"
@@ -473,8 +377,8 @@ const ExerciseList = () => {
                     {t("ExerciseList:filter.persons.titleWithNumbers", {
                       minValue: exerciseFilter.minPersons,
                       maxValue:
-                        exerciseFilter.maxPersons === maxPersons
-                          ? `${maxPersons}+`
+                        exerciseFilter.maxPersons === MAX_PERSONS
+                          ? `${MAX_PERSONS}+`
                           : exerciseFilter.maxPersons,
                     })}
                   </SoftTypography>
@@ -486,17 +390,15 @@ const ExerciseList = () => {
                     ]}
                     onChange={(_event: Event, newValue: number | number[]) => {
                       const [newMin, newMax] = newValue as number[];
-                      setLoadedExercises([]);
                       setExerciseFilter((prev) => ({
                         ...prev,
                         maxPersons: newMax,
                         minPersons: newMin,
-                        page: 1,
                       }));
                     }}
                     valueLabelDisplay="auto"
                     getAriaValueText={(value: number) => value.toString()}
-                    max={maxPersons}
+                    max={MAX_PERSONS}
                     min={0}
                   />
                 </Grid>
@@ -506,8 +408,8 @@ const ExerciseList = () => {
                     {t("ExerciseList:filter.timeInMinutes.titleWithNumbers", {
                       minValue: exerciseFilter.minTime,
                       maxValue:
-                        exerciseFilter.maxTime === maxTime
-                          ? `${maxTime}+`
+                        exerciseFilter.maxTime === MAX_TIME
+                          ? `${MAX_TIME}+`
                           : exerciseFilter.maxTime,
                     })}
                   </SoftTypography>
@@ -516,17 +418,15 @@ const ExerciseList = () => {
                     value={[exerciseFilter.minTime, exerciseFilter.maxTime]}
                     onChange={(_event: Event, newValue: number | number[]) => {
                       const [newMin, newMax] = newValue as number[];
-                      setLoadedExercises([]);
                       setExerciseFilter({
                         ...exerciseFilter,
                         minTime: newMin,
                         maxTime: newMax,
-                        page: 1,
                       });
                     }}
                     valueLabelDisplay="auto"
                     getAriaValueText={(value: number) => `${value} minutes`}
-                    max={maxTime}
+                    max={MAX_TIME}
                     min={0}
                   />
                 </Grid>
@@ -536,8 +436,8 @@ const ExerciseList = () => {
                     {t("ExerciseList:filter.beaters.titleWithNumbers", {
                       minValue: exerciseFilter.minBeaters,
                       maxValue:
-                        exerciseFilter.maxBeaters === maxBeaters
-                          ? `${maxBeaters}+`
+                        exerciseFilter.maxBeaters === MAX_BEATERS
+                          ? `${MAX_BEATERS}+`
                           : exerciseFilter.maxBeaters,
                     })}
                   </SoftTypography>
@@ -549,17 +449,15 @@ const ExerciseList = () => {
                     ]}
                     onChange={(_event: Event, newValue: number | number[]) => {
                       const [newMin, newMax] = newValue as number[];
-                      setLoadedExercises([]);
                       setExerciseFilter({
                         ...exerciseFilter,
                         minBeaters: newMin,
                         maxBeaters: newMax,
-                        page: 1,
                       });
                     }}
                     valueLabelDisplay="auto"
                     getAriaValueText={(value: number) => value.toString()}
-                    max={maxBeaters}
+                    max={MAX_BEATERS}
                     min={0}
                   />
                 </Grid>
@@ -569,8 +467,8 @@ const ExerciseList = () => {
                     {t("ExerciseList:filter.chasers.titleWithNumbers", {
                       minValue: exerciseFilter.minChasers,
                       maxValue:
-                        exerciseFilter.maxChasers === maxChasers
-                          ? `${maxChasers}+`
+                        exerciseFilter.maxChasers === MAX_CHASERS
+                          ? `${MAX_CHASERS}+`
                           : exerciseFilter.maxChasers,
                     })}
                   </SoftTypography>
@@ -582,17 +480,15 @@ const ExerciseList = () => {
                     ]}
                     onChange={(_event: Event, newValue: number | number[]) => {
                       const [newMin, newMax] = newValue as number[];
-                      setLoadedExercises([]);
                       setExerciseFilter({
                         ...exerciseFilter,
                         minChasers: newMin,
                         maxChasers: newMax,
-                        page: 1,
                       });
                     }}
                     valueLabelDisplay="auto"
                     getAriaValueText={(value: number) => value.toString()}
-                    max={maxChasers}
+                    max={MAX_CHASERS}
                     min={0}
                   />
                 </Grid>
@@ -757,8 +653,7 @@ const ExerciseList = () => {
                   }}
                 />
               </SoftBox>
-              {exercisesData &&
-                exerciseFilter.page < exercisesData.pagination.pages && (
+              {pagination && pagination.page < pagination.pages && (
                   <SoftBox
                     display="flex"
                     justifyContent="center"
@@ -766,7 +661,7 @@ const ExerciseList = () => {
                   >
                     <SoftButton
                       onClick={loadMore}
-                      disabled={isExercisesLoading}
+                      disabled={isLoadingMore}
                     >
                       {t("ExerciseList:loadMore")}
                     </SoftButton>

--- a/client/src/pages/Exercises/ExerciseList/useExerciseListQuery.test.tsx
+++ b/client/src/pages/Exercises/ExerciseList/useExerciseListQuery.test.tsx
@@ -1,0 +1,302 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ExerciseSummary } from "../../../api/quadcoachApi/domain";
+import type { GetExercisesResponse } from "../../exerciseApi";
+import {
+  ExerciseFilter,
+  LazyGetExercisesTrigger,
+  MAX_BEATERS,
+  MAX_CHASERS,
+  MAX_PERSONS,
+  MAX_TIME,
+  toGetExercisesRequest,
+  useExerciseListQuery,
+} from "./useExerciseListQuery";
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (error: unknown) => void;
+};
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+const defaultFilter: ExerciseFilter = {
+  searchValue: "",
+  minPersons: 0,
+  maxPersons: MAX_PERSONS,
+  tagInput: "",
+  tags: [],
+  materialInput: "",
+  materials: [],
+  minTime: 0,
+  maxTime: MAX_TIME,
+  minBeaters: 0,
+  maxBeaters: MAX_BEATERS,
+  minChasers: 0,
+  maxChasers: MAX_CHASERS,
+  sort: "name",
+  direction: "asc",
+  limit: 50,
+};
+
+function exercise(id: string, name = `Exercise ${id}`): ExerciseSummary {
+  return {
+    _id: id,
+    name,
+    tags: [],
+    materials: [],
+    durationMinutes: null,
+    persons: null,
+    beaters: null,
+    chasers: null,
+    relatedTo: [],
+  };
+}
+
+function page(
+  items: ExerciseSummary[],
+  pageNumber = 1,
+  pages = 1,
+): GetExercisesResponse {
+  return {
+    items,
+    pagination: {
+      page: pageNumber,
+      limit: 50,
+      total: items.length,
+      pages,
+    },
+  };
+}
+
+function createTriggerMock() {
+  const requests: Array<{
+    deferred: Deferred<GetExercisesResponse>;
+    abort: ReturnType<typeof vi.fn>;
+  }> = [];
+  const getExercises = vi.fn(() => {
+    const request = {
+      deferred: deferred<GetExercisesResponse>(),
+      abort: vi.fn(),
+    };
+    requests.push(request);
+    return {
+      abort: request.abort,
+      unwrap: () => request.deferred.promise,
+    };
+  }) as unknown as LazyGetExercisesTrigger;
+
+  return { getExercises, requests };
+}
+
+describe("toGetExercisesRequest", () => {
+  it("trims partial tag text and preserves exact selections and sentinels", () => {
+    expect(
+      toGetExercisesRequest(
+        {
+          ...defaultFilter,
+          tagInput: "  WaR.*  ",
+          tags: ["Warmup"],
+        },
+        3,
+      ),
+    ).toEqual(
+      expect.objectContaining({
+        tagSearch: "WaR.*",
+        tags: ["Warmup"],
+        tagMode: "all",
+        personsMin: undefined,
+        personsMax: undefined,
+        page: 3,
+      }),
+    );
+  });
+
+  it("omits whitespace-only partial tag text", () => {
+    expect(
+      toGetExercisesRequest({ ...defaultFilter, tagInput: "   " }, 1)
+        .tagSearch,
+    ).toBeUndefined();
+  });
+});
+
+describe("useExerciseListQuery", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it("restarts the debounce when the filter changes", () => {
+    const { getExercises } = createTriggerMock();
+    const { rerender } = renderHook(
+      ({ filter }) =>
+        useExerciseListQuery({ filter, debounceMs: 500, getExercises }),
+      { initialProps: { filter: defaultFilter } },
+    );
+
+    act(() => vi.advanceTimersByTime(499));
+    expect(getExercises).not.toHaveBeenCalled();
+
+    rerender({ filter: { ...defaultFilter, tagInput: "fen" } });
+    act(() => vi.advanceTimersByTime(499));
+    expect(getExercises).not.toHaveBeenCalled();
+
+    act(() => vi.advanceTimersByTime(1));
+    expect(getExercises).toHaveBeenCalledTimes(1);
+    expect(getExercises).toHaveBeenCalledWith(
+      expect.objectContaining({ tagSearch: "fen", page: 1 }),
+    );
+  });
+
+  it("replaces first-page results and reports active request errors", async () => {
+    const { getExercises, requests } = createTriggerMock();
+    const { result, rerender } = renderHook(
+      ({ filter }) =>
+        useExerciseListQuery({ filter, debounceMs: 500, getExercises }),
+      { initialProps: { filter: defaultFilter } },
+    );
+
+    act(() => vi.advanceTimersByTime(500));
+    await act(async () => requests[0].deferred.resolve(page([exercise("1")])))
+    expect(result.current.status).toBe("ready");
+    expect(result.current.exercises.map(({ _id }) => _id)).toEqual(["1"]);
+
+    rerender({ filter: { ...defaultFilter, tagInput: "new" } });
+    expect(result.current.status).toBe("loading");
+    expect(result.current.exercises).toEqual([]);
+    act(() => vi.advanceTimersByTime(500));
+    await act(async () => requests[1].deferred.reject(new Error("failed")));
+    expect(result.current.status).toBe("error");
+  });
+
+  it("ignores stale successes and failures", async () => {
+    const { getExercises, requests } = createTriggerMock();
+    const { result, rerender } = renderHook(
+      ({ filter }) =>
+        useExerciseListQuery({ filter, debounceMs: 500, getExercises }),
+      { initialProps: { filter: defaultFilter } },
+    );
+
+    act(() => vi.advanceTimersByTime(500));
+    rerender({ filter: { ...defaultFilter, tagInput: "second" } });
+    act(() => vi.advanceTimersByTime(500));
+    await act(async () =>
+      requests[0].deferred.resolve(page([exercise("stale")]))
+    );
+    expect(result.current.status).toBe("loading");
+    expect(result.current.exercises).toEqual([]);
+
+    rerender({ filter: { ...defaultFilter, tagInput: "third" } });
+    act(() => vi.advanceTimersByTime(500));
+    await act(async () => requests[1].deferred.reject(new Error("stale")));
+    expect(result.current.status).toBe("loading");
+
+    await act(async () =>
+      requests[2].deferred.resolve(page([exercise("current")]))
+    );
+    expect(result.current.status).toBe("ready");
+    expect(result.current.exercises.map(({ _id }) => _id)).toEqual([
+      "current",
+    ]);
+  });
+
+  it("aborts superseded and unmounted requests", () => {
+    const { getExercises, requests } = createTriggerMock();
+    const { rerender, unmount } = renderHook(
+      ({ filter }) =>
+        useExerciseListQuery({ filter, debounceMs: 500, getExercises }),
+      { initialProps: { filter: defaultFilter } },
+    );
+
+    act(() => vi.advanceTimersByTime(500));
+    rerender({ filter: { ...defaultFilter, tagInput: "next" } });
+    expect(requests[0].abort).toHaveBeenCalledOnce();
+
+    act(() => vi.advanceTimersByTime(500));
+    unmount();
+    expect(requests[1].abort).toHaveBeenCalledOnce();
+  });
+
+  it("appends deduplicated pages and surfaces pagination failures", async () => {
+    const { getExercises, requests } = createTriggerMock();
+    const { result } = renderHook(() =>
+      useExerciseListQuery({
+        filter: defaultFilter,
+        debounceMs: 500,
+        getExercises,
+      }),
+    );
+
+    act(() => vi.advanceTimersByTime(500));
+    await act(async () =>
+      requests[0].deferred.resolve(page([exercise("1", "Old")], 1, 3))
+    );
+
+    act(() => result.current.loadMore());
+    expect(result.current.isLoadingMore).toBe(true);
+    expect(getExercises).toHaveBeenLastCalledWith(
+      expect.objectContaining({ page: 2 }),
+    );
+    await act(async () =>
+      requests[1].deferred.resolve(
+        page([exercise("1", "Updated"), exercise("2")], 2, 3),
+      )
+    );
+    expect(result.current.exercises.map(({ _id }) => _id)).toEqual(["1", "2"]);
+    expect(result.current.exercises[0].name).toBe("Updated");
+    expect(result.current.isLoadingMore).toBe(false);
+
+    act(() => result.current.loadMore());
+    await act(async () =>
+      requests[2].deferred.reject(new Error("pagination failed"))
+    );
+    expect(result.current.status).toBe("error");
+    expect(result.current.exercises.map(({ _id }) => _id)).toEqual(["1", "2"]);
+    expect(result.current.isLoadingMore).toBe(false);
+  });
+
+  it("rejects a pagination response after the filter changes", async () => {
+    const { getExercises, requests } = createTriggerMock();
+    const { result, rerender } = renderHook(
+      ({ filter }) =>
+        useExerciseListQuery({ filter, debounceMs: 500, getExercises }),
+      { initialProps: { filter: defaultFilter } },
+    );
+
+    act(() => vi.advanceTimersByTime(500));
+    await act(async () =>
+      requests[0].deferred.resolve(page([exercise("1")], 1, 2))
+    );
+    act(() => result.current.loadMore());
+
+    rerender({ filter: { ...defaultFilter, tagInput: "latest" } });
+    expect(requests[1].abort).toHaveBeenCalledOnce();
+    expect(result.current.exercises).toEqual([]);
+    await act(async () =>
+      requests[1].deferred.resolve(page([exercise("stale-page")], 2, 2))
+    );
+    expect(result.current.exercises).toEqual([]);
+
+    act(() => vi.advanceTimersByTime(500));
+    await act(async () =>
+      requests[2].deferred.resolve(page([exercise("latest")]))
+    );
+    expect(result.current.exercises.map(({ _id }) => _id)).toEqual(["latest"]);
+  });
+});

--- a/client/src/pages/Exercises/ExerciseList/useExerciseListQuery.ts
+++ b/client/src/pages/Exercises/ExerciseList/useExerciseListQuery.ts
@@ -1,0 +1,213 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { ExerciseSummary } from "../../../api/quadcoachApi/domain";
+import type {
+  GetExercisesRequest,
+  GetExercisesResponse,
+} from "../../exerciseApi";
+
+export const MAX_PERSONS = 20;
+export const MAX_TIME = 60;
+export const MAX_CHASERS = 10;
+export const MAX_BEATERS = 10;
+
+export type ExerciseFilter = {
+  searchValue: string;
+  minPersons: number;
+  maxPersons: number;
+  tagInput: string;
+  tags: string[];
+  materialInput: string;
+  materials: string[];
+  minTime: number;
+  maxTime: number;
+  minBeaters: number;
+  maxBeaters: number;
+  minChasers: number;
+  maxChasers: number;
+  sort: "name" | "duration" | "persons" | "created" | "updated";
+  direction: "asc" | "desc";
+  limit: number;
+};
+
+export type ExerciseListQueryStatus = "loading" | "ready" | "error";
+
+type ExerciseQueryTriggerResult = {
+  abort: () => void;
+  unwrap: () => Promise<GetExercisesResponse>;
+};
+
+export type LazyGetExercisesTrigger = (
+  request: GetExercisesRequest,
+) => ExerciseQueryTriggerResult;
+
+type UseExerciseListQueryOptions = {
+  filter: ExerciseFilter;
+  debounceMs?: number;
+  getExercises: LazyGetExercisesTrigger;
+};
+
+export type UseExerciseListQueryResult = {
+  exercises: ExerciseSummary[];
+  pagination: GetExercisesResponse["pagination"] | null;
+  status: ExerciseListQueryStatus;
+  isLoadingMore: boolean;
+  loadMore: () => void;
+};
+
+type ExercisePageRequest = {
+  generation: number;
+  page: number;
+  query: GetExercisesRequest;
+};
+
+export function toGetExercisesRequest(
+  filter: ExerciseFilter,
+  page: number,
+): GetExercisesRequest {
+  const tagSearch = filter.tagInput.trim();
+
+  return {
+    personsMax:
+      filter.maxPersons === MAX_PERSONS ? undefined : filter.maxPersons,
+    personsMin: filter.minPersons === 0 ? undefined : filter.minPersons,
+    search: filter.searchValue,
+    tagSearch: tagSearch || undefined,
+    tags: filter.tags,
+    tagMode: "all",
+    materials: filter.materials,
+    materialMode: "all",
+    durationMin: filter.minTime === 0 ? undefined : filter.minTime,
+    durationMax: filter.maxTime === MAX_TIME ? undefined : filter.maxTime,
+    beatersMin: filter.minBeaters === 0 ? undefined : filter.minBeaters,
+    beatersMax:
+      filter.maxBeaters === MAX_BEATERS ? undefined : filter.maxBeaters,
+    chasersMin: filter.minChasers === 0 ? undefined : filter.minChasers,
+    chasersMax:
+      filter.maxChasers === MAX_CHASERS ? undefined : filter.maxChasers,
+    sort: filter.sort,
+    direction: filter.direction,
+    page,
+    limit: filter.limit,
+  };
+}
+
+function mergeExercisePage(
+  current: ExerciseSummary[],
+  incoming: ExerciseSummary[],
+): ExerciseSummary[] {
+  const exercisesById = new Map(
+    current.map((exercise) => [exercise._id, exercise]),
+  );
+  incoming.forEach((exercise) => exercisesById.set(exercise._id, exercise));
+  return Array.from(exercisesById.values());
+}
+
+export function useExerciseListQuery({
+  filter,
+  debounceMs = 500,
+  getExercises,
+}: UseExerciseListQueryOptions): UseExerciseListQueryResult {
+  const [exercises, setExercises] = useState<ExerciseSummary[]>([]);
+  const [pagination, setPagination] = useState<
+    GetExercisesResponse["pagination"] | null
+  >(null);
+  const [status, setStatus] = useState<ExerciseListQueryStatus>("loading");
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+
+  const activeGenerationRef = useRef(0);
+  const activeRequestRef = useRef<ExerciseQueryTriggerResult | null>(null);
+  const activeFilterRef = useRef(filter);
+  const isLoadingMoreRef = useRef(false);
+
+  const loadExercises = useCallback(
+    async (request: ExercisePageRequest): Promise<void> => {
+      const trigger = getExercises(request.query);
+      activeRequestRef.current = trigger;
+
+      try {
+        const response = await trigger.unwrap();
+        if (request.generation !== activeGenerationRef.current) return;
+
+        setExercises((current) =>
+          request.page === 1
+            ? response.items
+            : mergeExercisePage(current, response.items),
+        );
+        setPagination(response.pagination);
+        setStatus("ready");
+      } catch {
+        if (request.generation !== activeGenerationRef.current) return;
+        setStatus("error");
+      } finally {
+        if (activeRequestRef.current === trigger) {
+          activeRequestRef.current = null;
+        }
+        if (request.generation === activeGenerationRef.current) {
+          isLoadingMoreRef.current = false;
+          setIsLoadingMore(false);
+        }
+      }
+    },
+    [getExercises],
+  );
+
+  useEffect(() => {
+    const generation = ++activeGenerationRef.current;
+    activeFilterRef.current = filter;
+    activeRequestRef.current?.abort();
+    activeRequestRef.current = null;
+    isLoadingMoreRef.current = false;
+
+    setExercises([]);
+    setPagination(null);
+    setStatus("loading");
+    setIsLoadingMore(false);
+
+    const timer = window.setTimeout(() => {
+      void loadExercises({
+        generation,
+        page: 1,
+        query: toGetExercisesRequest(filter, 1),
+      });
+    }, debounceMs);
+
+    return () => window.clearTimeout(timer);
+  }, [debounceMs, filter, loadExercises]);
+
+  useEffect(
+    () => () => {
+      ++activeGenerationRef.current;
+      activeRequestRef.current?.abort();
+      activeRequestRef.current = null;
+    },
+    [],
+  );
+
+  const loadMore = useCallback(() => {
+    if (
+      status !== "ready" ||
+      isLoadingMoreRef.current ||
+      pagination === null ||
+      pagination.page >= pagination.pages
+    ) {
+      return;
+    }
+
+    const page = pagination.page + 1;
+    isLoadingMoreRef.current = true;
+    setIsLoadingMore(true);
+    void loadExercises({
+      generation: activeGenerationRef.current,
+      page,
+      query: toGetExercisesRequest(activeFilterRef.current, page),
+    });
+  }, [loadExercises, pagination, status]);
+
+  return {
+    exercises,
+    pagination,
+    status,
+    isLoadingMore,
+    loadMore,
+  };
+}

--- a/client/src/pages/exerciseApi.contract.test.ts
+++ b/client/src/pages/exerciseApi.contract.test.ts
@@ -39,8 +39,9 @@ describe("Exercise collection API contract", () => {
     await store.dispatch(
       exerciseApiSlice.endpoints.getExercises.initiate({
         search: "Press .* [one]",
+        tagSearch: "fen [one].*",
         tags: ["Defense", "Fast play"],
-        tagMode: "any",
+        tagMode: "all",
         materials: ["Hoops", "Cones"],
         materialMode: "all",
         personsMin: 2,
@@ -59,7 +60,7 @@ describe("Exercise collection API contract", () => {
     );
 
     expect(lastRequest()).toEqual({
-      url: "/api/exercises?search=Press+.*+%5Bone%5D&tags=Defense&tags=Fast+play&tagMode=any&materials=Hoops&materials=Cones&materialMode=all&personsMin=2&personsMax=12&durationMin=5&durationMax=30&beatersMin=1&beatersMax=4&chasersMin=3&chasersMax=6&sort=duration&direction=desc&page=3&limit=25",
+      url: "/api/exercises?search=Press+.*+%5Bone%5D&tagSearch=fen+%5Bone%5D.*&tags=Defense&tags=Fast+play&tagMode=all&materials=Hoops&materials=Cones&materialMode=all&personsMin=2&personsMax=12&durationMin=5&durationMax=30&beatersMin=1&beatersMax=4&chasersMin=3&chasersMax=6&sort=duration&direction=desc&page=3&limit=25",
       method: "get",
     });
   });

--- a/client/src/pages/exerciseApi.ts
+++ b/client/src/pages/exerciseApi.ts
@@ -16,6 +16,7 @@ import {
 
 export type GetExercisesRequest = {
   search?: string;
+  tagSearch?: string;
   tags?: string[];
   tagMode?: "all" | "any";
   materials?: string[];
@@ -187,6 +188,7 @@ export const exerciseApiSlice = quadcoachApi.injectEndpoints({
       query: (request) => {
         const {
           search,
+          tagSearch,
           tags,
           tagMode,
           materials,
@@ -207,6 +209,7 @@ export const exerciseApiSlice = quadcoachApi.injectEndpoints({
         const urlParams = new URLSearchParams();
 
         if (search) urlParams.append("search", search);
+        if (tagSearch) urlParams.append("tagSearch", tagSearch);
         tags?.forEach((tag) => urlParams.append("tags", tag));
         if (tags?.length && tagMode) urlParams.append("tagMode", tagMode);
         materials?.forEach((material) =>

--- a/client/vitest.config.ts
+++ b/client/vitest.config.ts
@@ -3,6 +3,6 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     environment: "node",
-    include: ["src/**/*.test.ts"],
+    include: ["src/**/*.test.{ts,tsx}"],
   },
 });

--- a/server/collectionQuery/index.ts
+++ b/server/collectionQuery/index.ts
@@ -213,8 +213,21 @@ function rangeMatch(range: IntegerRange): mongo.Document {
 function callerMatch(intent: CollectionIntent): mongo.Filter<mongo.Document> {
   const match: mongo.Filter<mongo.Document> = {};
   if (intent.search) match.name = new RegExp(escapeRegex(intent.search), "i");
-  if (intent.tags) match.tags = selectionMatch(intent.tags);
   if (intent.resource === "exercise") {
+    const tagPredicates: mongo.Document[] = [];
+    if (intent.tags) {
+      tagPredicates.push({ tags: selectionMatch(intent.tags) });
+    }
+    if (intent.tagSearch) {
+      tagPredicates.push({
+        tags: new RegExp(escapeRegex(intent.tagSearch), "i"),
+      });
+    }
+    if (tagPredicates.length === 1) {
+      Object.assign(match, tagPredicates[0]);
+    } else if (tagPredicates.length > 1) {
+      match.$and = tagPredicates;
+    }
     const fields: readonly [
       keyof Pick<
         ExerciseIntent,
@@ -232,8 +245,11 @@ function callerMatch(intent: CollectionIntent): mongo.Filter<mongo.Document> {
       const selectedRange = intent[semanticField];
       if (selectedRange) match[persistenceField] = rangeMatch(selectedRange);
     }
-  } else if (intent.privacy) {
-    match.isPrivate = intent.privacy === "private" ? true : { $ne: true };
+  } else {
+    if (intent.tags) match.tags = selectionMatch(intent.tags);
+    if (intent.privacy) {
+      match.isPrivate = intent.privacy === "private" ? true : { $ne: true };
+    }
   }
   return match;
 }

--- a/server/collectionQuery/parser.ts
+++ b/server/collectionQuery/parser.ts
@@ -58,6 +58,7 @@ const commonFields = new Set([
 ]);
 const exerciseFields = new Set([
   ...commonFields,
+  "tagSearch",
   "materials",
   "materialMode",
   "personsMin",
@@ -81,6 +82,7 @@ function singleton(
   query: Query,
   field: string,
   errors: CollectionQueryError[],
+  blankBehavior: "reject" | "omit" = "reject",
 ): string | undefined {
   const value = query[field];
   if (value === undefined) return undefined;
@@ -95,7 +97,7 @@ function singleton(
   }
   const trimmed = values[0].trim();
   if (!trimmed) {
-    errors.push({ field, code: "blank" });
+    if (blankBehavior === "reject") errors.push({ field, code: "blank" });
     return undefined;
   }
   if (trimmed.length > (field === "search" ? 200 : 100)) {
@@ -246,6 +248,7 @@ export function parseCollectionQuery(
   }
   const direction = rawDirection === "desc" ? "desc" : "asc";
   if (resource === "exercise") {
+    const tagSearch = singleton(query, "tagSearch", errors, "omit");
     const by: ExerciseIntentInput["sort"]["by"] =
       rawSort === "created" ||
       rawSort === "updated" ||
@@ -256,6 +259,7 @@ export function parseCollectionQuery(
     const intent: ExerciseIntentInput = {
       resource,
       search,
+      ...(tagSearch ? { tagSearch } : {}),
       tags,
       materials: selectedValues(query, "materials", "materialMode", errors),
       persons: range(query, "persons", errors),

--- a/server/collectionQuery/types.ts
+++ b/server/collectionQuery/types.ts
@@ -32,6 +32,7 @@ export interface ExerciseIntentInput extends CommonIntent<
   CommonSort | "duration" | "persons"
 > {
   readonly resource: "exercise";
+  readonly tagSearch?: string;
   readonly materials?: ValueSelection;
   readonly persons?: IntegerRange;
   readonly duration?: IntegerRange;

--- a/server/tests/contract/collectionQuery.issue145.mongo.contract.spec.ts
+++ b/server/tests/contract/collectionQuery.issue145.mongo.contract.spec.ts
@@ -110,6 +110,36 @@ describe("collection query Mongo contract", () => {
     expect(bounded.items[0]).not.toHaveProperty("description_blocks");
   });
 
+  it("matches partial tags literally and combines them with exact tags", async () => {
+    const database = mongoose.connection.db!;
+    await database.collection("exercises").insertMany([
+      { name: "Combined", tags: ["Warmup", "Team Defense"] },
+      { name: "Wrong exact tag", tags: ["Cooldown", "Defense"] },
+      { name: "Wrong partial tag", tags: ["Warmup", "Attack"] },
+      { name: "Literal punctuation", tags: ["Pattern [one].*"] },
+      { name: "Regex-like only", tags: ["Pattern onexxx"] },
+    ]);
+    const visible = collectionVisibility.all();
+
+    const combined = await browse({
+      intent: parseCollectionQuery("exercise", {
+        tags: "warmup",
+        tagMode: "all",
+        tagSearch: "FEN",
+      }),
+      visibility: visible,
+    });
+    expect(combined.items.map((item) => item.name)).toEqual(["Combined"]);
+
+    const literal = await browse({
+      intent: parseCollectionQuery("exercise", { tagSearch: "[one].*" }),
+      visibility: visible,
+    });
+    expect(literal.items.map((item) => item.name)).toEqual([
+      "Literal punctuation",
+    ]);
+  });
+
   it("supports stable pages, successful beyond-end pages, and derived plan summaries", async () => {
     const database = mongoose.connection.db!;
     await database.collection("practiceplans").insertMany([

--- a/server/tests/contract/exerciseCollection.issue146.http.contract.spec.ts
+++ b/server/tests/contract/exerciseCollection.issue146.http.contract.spec.ts
@@ -99,6 +99,49 @@ describe("issue 146 Exercise collection HTTP contract", () => {
     });
   });
 
+  it("combines exact tags with a literal partial tag over HTTP", async () => {
+    await mongoose.connection.db!.collection("exercises").insertMany([
+      { name: "Combined", tags: ["Warmup", "Defense"] },
+      { name: "Missing exact", tags: ["Defense"] },
+      { name: "Missing partial", tags: ["Warmup", "Attack"] },
+      { name: "Literal", tags: ["Warmup", "Pattern [one].*"] },
+      { name: "Regex-like", tags: ["Warmup", "Pattern onexxx"] },
+    ]);
+
+    const combined = await request(app)
+      .get("/api/exercises")
+      .query({ tags: "warmup", tagMode: "all", tagSearch: "FEN" })
+      .expect(200);
+    expect(
+      combined.body.items.map((item: { name: string }) => item.name),
+    ).toEqual(["Combined"]);
+
+    const literal = await request(app)
+      .get("/api/exercises")
+      .query({ tags: "warmup", tagMode: "all", tagSearch: "[one].*" })
+      .expect(200);
+    expect(literal.body.items.map((item: { name: string }) => item.name)).toEqual([
+      "Literal",
+    ]);
+  });
+
+  it("returns structured partial-tag validation failures", async () => {
+    const response = await request(app)
+      .get("/api/exercises")
+      .query({ tagSearch: ["first", "second"] })
+      .expect(400);
+
+    expect(response.body).toEqual({
+      message: "Invalid collection query",
+      errors: [{ field: "tagSearch", code: "duplicate" }],
+    });
+
+    await request(app)
+      .get("/api/exercises")
+      .query({ tagSearch: "   " })
+      .expect(200);
+  });
+
   it("returns strict validation envelopes for legacy and unknown syntax", async () => {
     const response = await request(app)
       .get("/api/exercises?name%5Bregex%5D=x&sortBy=time&limit=101")

--- a/server/tests/unit/collectionQueryParser.issue145.spec.ts
+++ b/server/tests/unit/collectionQueryParser.issue145.spec.ts
@@ -93,6 +93,38 @@ describe("collection query transport parser", () => {
     ]);
   });
 
+  it("normalizes an exercise-only partial tag search", () => {
+    const intent = parseCollectionQuery("exercise", {
+      tagSearch: "  Fast play  ",
+    });
+
+    expect(intent).toMatchObject({ tagSearch: "Fast play" });
+    expect(Object.isFrozen(intent)).toBe(true);
+    expect(parseCollectionQuery("exercise", { tagSearch: "   " })).not.toHaveProperty(
+      "tagSearch",
+    );
+    expect(errorsFor("tacticBoard", { tagSearch: "fast" }).errors).toEqual([
+      { field: "tagSearch", code: "unknown" },
+    ]);
+  });
+
+  it("rejects invalid partial tag search values", () => {
+    expect(
+      errorsFor("exercise", {
+        tagSearch: ["fast", "play"],
+      }).errors,
+    ).toEqual([{ field: "tagSearch", code: "duplicate" }]);
+    expect(errorsFor("exercise", { tagSearch: { value: "fast" } }).errors).toEqual(
+      [{ field: "tagSearch", code: "malformed" }],
+    );
+    expect(
+      errorsFor("exercise", { tagSearch: "x".repeat(101) }).errors,
+    ).toEqual([{ field: "tagSearch", code: "outOfRange" }]);
+    expect(
+      parseCollectionQuery("exercise", { tagSearch: "x".repeat(100) }),
+    ).toMatchObject({ tagSearch: "x".repeat(100) });
+  });
+
   it("keeps resource vocabularies closed", () => {
     expect(
       errorsFor("tacticBoard", { materials: "cones", privacy: "secret" })


### PR DESCRIPTION
[#154](https://github.com/wienans/quadcoach/issues/154) | [Artifacts](https://cloud.humanlayer.com/artifacts/019fadcc-beac-739e-935a-41e4ff6305cb) | [PR Walkthrough (alpha)](https://cloud.humanlayer.com/artifacts/019fae3b-6517-7736-a0e5-1051b2ba9601)

## What problems was I solving

Exercise tag filtering stopped reacting to text while a coach typed. Results only reflected tags after Enter committed the text as an exact tag chip, removing the fast feedback users previously had when finding exercises by a partial tag.

This PR restores debounced, case-insensitive partial-tag filtering while preserving exact selected tags. It also prevents superseded requests, stale responses, and old pagination results from replacing the active query state when users type or clear filters quickly.

## What user-facing changes did I ship

- [Exercise tag input](https://github.com/wienans/quadcoach/pull/155/files#diff-6666722e7ee3ccea14549320ee153324a9e1b6a284f86b6fbe7df5d341f281fa) - Exercise results now enter a loading state immediately and refresh after a 500 ms pause while typing a tag fragment.
- [Partial tag matching](https://github.com/wienans/quadcoach/pull/155/files#diff-ff1957abf36bd7d92d9ef0445af14c57d1fa7a499bd9899cb111ae755cc6a14f) - Partial text matches tags case-insensitively and treats regex-like punctuation literally.
- [Exact and partial composition](https://github.com/wienans/quadcoach/pull/155/files#diff-ff1957abf36bd7d92d9ef0445af14c57d1fa7a499bd9899cb111ae755cc6a14f) - Committed tag chips remain exact requirements while in-progress text further narrows the same result set.
- [Race-safe result updates](https://github.com/wienans/quadcoach/pull/155/files#diff-0a8c8f8193fdd7465b04da8164b846bb2aa1cc5c635a0c7e39d7f31bbaf8b808) - Clearing or changing filters no longer allows an obsolete request or pagination response to overwrite current results.

## How I implemented it

### Backend Changes

- [Collection query types](https://github.com/wienans/quadcoach/pull/155/files#diff-ad22cabe94f5c077a4274e20358d8a894ca5cb3885291e25a14a5966dcd28fb6) - Adds the exercise-only `tagSearch` intent field.
- [Transport parser](https://github.com/wienans/quadcoach/pull/155/files#diff-0d36ab5e11ce7e3d5a658e7ba6e6a98d17f91d6fea2a59d54163b4252ca5077c) - Trims partial text, omits blank values, enforces singleton/length validation, and rejects the field for other resources.
- [Mongo query builder](https://github.com/wienans/quadcoach/pull/155/files#diff-ff1957abf36bd7d92d9ef0445af14c57d1fa7a499bd9899cb111ae755cc6a14f) - Combines exact selection and escaped partial matching with `$and` when both are present.
- [HTTP and Mongo contracts](https://github.com/wienans/quadcoach/pull/155/files#diff-04c9e76710caa318da808572f7e20e7f5273df72d0691f4aac7c5369f14e5392) - Covers mixed exact/partial matching, literal punctuation, blank omission, and structured validation failures.

### Frontend Changes

- [Exercise API](https://github.com/wienans/quadcoach/pull/155/files#diff-c30b87129f54bbececd0d228fcb559b098c7ebd7cd70a36b2b23fe950be04d69) - Adds `tagSearch` to the typed request and serializes it into the collection URL.
- [Exercise query hook](https://github.com/wienans/quadcoach/pull/155/files#diff-0a8c8f8193fdd7465b04da8164b846bb2aa1cc5c635a0c7e39d7f31bbaf8b808) - Centralizes request mapping, debounce timing, generations, cancellation, loading/error state, and deduplicated pagination.
- [Exercise list integration](https://github.com/wienans/quadcoach/pull/155/files#diff-6666722e7ee3ccea14549320ee153324a9e1b6a284f86b6fbe7df5d341f281fa) - Replaces component-level Lodash debounce and response merging with the query hook while preserving the existing filter UI.
- [Hook tests](https://github.com/wienans/quadcoach/pull/155/files#diff-b3bc72792dcb3d42013eed933be47500ec5c6df42871e155e106aed69b2d718a) - Uses deferred requests and fake timers to prove debounce restarts, stale-response rejection, aborts, and pagination behavior.
- [Component test](https://github.com/wienans/quadcoach/pull/155/files#diff-6cda09b5c390491f05055608c5f43d549760aeee02e6dfc850dc1ebcd727128a) - Exercises typed, committed, cleared, loading, and active-error states through the rendered page.

### Database Changes

- No schema, migration, or stored-document changes are required.

## Deviations from the plan

No plan file was found. The task artifacts contain research questions, research, a PRD, a TDD, and a structure outline rather than an implementation plan.

## How to verify it

Create a worktree for the PR branch if needed:

```bash
git fetch origin
git worktree add ../quadcoach-pr-155 origin/wienans-quadcoach-154-tag-filtering-doesnt-work-anymore-while-typing
```

### Manual Testing

- [ ] Open the exercise list, type part of an existing tag, pause for 500 ms, and confirm results update without pressing Enter.
- [ ] Press Enter to commit the tag and confirm it becomes an exact chip while results remain filtered.
- [ ] Type a second partial tag and confirm both the exact chip and partial text must match.
- [ ] Type and clear text quickly and confirm stale results or stale errors never replace the active loading/result state.
- [ ] Use a fragment containing regex punctuation such as `[one].*` and confirm it is matched literally.
- [ ] Load another page, then change the filter and confirm old-page exercises do not appear in the new result set.

### Automated Tests

```bash
cd client
npm test
npm run build
npm run lint

cd ../server
npm run verify
```

## Description for the changelog

Restore debounced exercise filtering while typing partial tags, with race-safe loading and pagination.
